### PR TITLE
bugfix #2337 OnDetails behaviour and filters

### DIFF
--- a/frontend/src/App.elm
+++ b/frontend/src/App.elm
@@ -56,7 +56,7 @@ init : Route -> ( Model, Cmd Msg )
 init route =
     let
         ( treeModel, treeCmd ) =
-            Tree.init
+            Debug.log "Init" Tree.init
 
         controlsModel =
             Controls.init ()
@@ -146,6 +146,7 @@ updateWithoutReturn msg model =
             ( model, Cmd.none )
 
         GenericNodeQueryResponse (Ok genericNode) ->
+            
             case genericNode of
                 GenericNode.IsFolder lineage ->
                     let
@@ -158,7 +159,10 @@ updateWithoutReturn msg model =
                     startQuery
                         (Query.OnFolder
                             { folder = List.Nonempty.head lineage
-                            , filters = Query.Filters.none
+                            -- KL: changed because of filters
+                            -- , filters = Query.Filters.none
+                            , filters = Query.getFilters model.query
+                                    |> Maybe.withDefault Query.Filters.none
                             }
                         )
                         model1
@@ -172,6 +176,8 @@ updateWithoutReturn msg model =
                         (Query.OnDetails
                             { folder = Query.getFolder model.query
                             , documentId = document.id
+                            , filters = Query.getFilters model.query
+                                    |> Maybe.withDefault Query.Filters.none
                             }
                         )
                         model

--- a/frontend/src/Article.elm
+++ b/frontend/src/Article.elm
@@ -21,6 +21,7 @@ import Query exposing (Query)
 import Query.Filter exposing (Filter)
 import Tree
 import Utils
+import Query.Filters
 
 
 type alias Context =
@@ -155,6 +156,8 @@ update context msg model =
                             Query.OnDetails
                                 { folder = folderQuery.folder
                                 , documentId = documentId
+                                -- KL: keep filters from original query
+                                , filters = folderQuery.filters
                                 }
                     )
 
@@ -187,6 +190,8 @@ update context msg model =
                             Query.OnDetails
                                 { folder = ftsQuery.folder
                                 , documentId = documentId
+                                -- KL: keep filters from original query
+                                , filters = ftsQuery.filters
                                 }
                     )
 

--- a/frontend/src/Article/Details.elm
+++ b/frontend/src/Article/Details.elm
@@ -84,6 +84,7 @@ update msg model =
             , Cmd.none
             )
 
+        -- Edit Metadata
         ApiMutationResponse _ _ (Err err) ->
             ( { model | mutationState = MutationError err }
             , Cmd.none

--- a/frontend/src/Article/Iterator.elm
+++ b/frontend/src/Article/Iterator.elm
@@ -17,6 +17,7 @@ import Html.Attributes
 import Html.Events
 import Maybe.Extra
 import Utils
+import Query.Filters
 
 
 type alias Context item =
@@ -53,6 +54,8 @@ init context documentId =
                 { detailsQuery =
                     { folder = context.folder
                     , documentId = documentId
+                    -- KL: added filter defaults
+                    , filters = Query.Filters.none
                     }
                 }
     in

--- a/frontend/src/Query.elm
+++ b/frontend/src/Query.elm
@@ -41,6 +41,7 @@ type Query
 type alias DetailsQuery =
     { folder : Folder
     , documentId : DocumentId
+    , filters : Filters
     }
 
 
@@ -103,10 +104,16 @@ setFolder : Folder -> Query -> Query
 setFolder folder query =
     case query of
         OnDetails subQuery ->
-            OnDetails { subQuery | folder = folder }
+            -- OnFolder { folder = folder, filters = Filters.none }
+            -- KL: changed from no Filters to:
+            OnFolder { folder = folder, filters = getFilters query
+                        |> Maybe.withDefault Filters.none
+                        }
+            -- KL: this was the bug:
+            -- OnDetails { subQuery | folder = folder }
 
         OnFolder subQuery ->
-            OnFolder { subQuery | folder = folder }
+            OnFolder { subQuery | folder = folder}
 
         OnFts subQuery ->
             OnFts { subQuery | folder = folder }
@@ -124,8 +131,9 @@ stopgapFolder maybeFolder query =
 getFilters : Query -> Maybe Filters
 getFilters query =
     case query of
-        OnDetails { folder } ->
-            Nothing
+        OnDetails { folder, filters } ->
+            -- KL: changed from: Nothing
+            Just filters
 
         OnFolder { filters } ->
             Just filters


### PR DESCRIPTION
Bugfix: Document details page stays open when clicking on tree and filters disappear
