### PR TITLE
Refactor API

### DIFF
--- a/backend/bin/build
+++ b/backend/bin/build
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-p="psql -d $MEDIATUM_DATABASE_NAME -U $MEDIATUM_DATABASE_USER -f"
+set -e # Abort execution on first failing command
+
+p="psql -d $MEDIATUM_DATABASE_NAME -U $MEDIATUM_DATABASE_USER  -v ON_ERROR_STOP=on -f"
 
 $p src/drop_all.sql
 $p src/types.sql

--- a/backend/bin/start
+++ b/backend/bin/start
@@ -30,5 +30,6 @@ postgraphile \
     --no-setof-functions-contain-nulls \
     --legacy-relations=omit \
     --no-ignore-rbac \
-
+    --enhance-graphiql \
+    
 #     --dynamic-json \

--- a/backend/src/api-document.sql
+++ b/backend/src/api-document.sql
@@ -3,9 +3,6 @@
 -- regarding document objects.
 
 
-begin;
-
-
 create or replace function api.all_documents
     ( folder_id int4
     , type text
@@ -112,6 +109,3 @@ $$ language sql stable parallel safe;
 
 comment on function api.document_values_by_mask (document api.document, mask_name text) is
     'Gets the meta field values of this document as a JSON value, selected by a named mask.';
-
-
-commit;

--- a/backend/src/api-facets.sql
+++ b/backend/src/api-facets.sql
@@ -2,9 +2,6 @@
 -- Publicly exposed GraphQL functions
 -- regarding facetted search.
 
-begin;
-
-
 create or replace function api.all_documents_docset
     ( folder_id int4
     , type text
@@ -264,5 +261,3 @@ comment on function api.all_documents_facet_by_mask
     'Note: When dealing with large sets of documents, this function is faster '
     'than composing the functions "all_documents_docset" and "docset_facet_by_mask".'
 ;
-
-commit;

--- a/backend/src/api-facets.sql
+++ b/backend/src/api-facets.sql
@@ -27,7 +27,7 @@ create or replace function api.all_documents_docset
 $$ language plpgsql stable parallel safe;
 
 
-create or replace function aux.fts_folder_docset
+create or replace function aux.fts_documents_tsquery_docset
     ( folder_id int4
     , fts_query tsquery
     , domain text
@@ -62,8 +62,8 @@ create or replace function aux.fts_folder_docset
 $$ language plpgsql stable parallel safe;
 
 
-create or replace function api.folder_fts_docset
-    ( folder api.folder
+create or replace function api.fts_documents_docset
+    ( folder_id int4
     , text text
     , domain text
     , language text
@@ -72,8 +72,8 @@ create or replace function api.folder_fts_docset
     returns api.docset
     as $$ 
     begin  
-        return aux.fts_folder_docset
-          ( folder.id
+        return aux.fts_documents_tsquery_docset
+          ( folder_id
           , plainto_tsquery (language::regconfig, text)
           , domain
           , language
@@ -82,8 +82,8 @@ create or replace function api.folder_fts_docset
     end;
 $$ language plpgsql stable parallel safe;
 
-comment on function api.folder_fts_docset
-    ( folder api.folder
+comment on function api.fts_documents_docset
+    ( folder_id int4
     , text text
     , domain text
     , language text

--- a/backend/src/api-folder.sql
+++ b/backend/src/api-folder.sql
@@ -3,9 +3,6 @@
 -- regarding folders (i.e. collections and directories).
 
 
-begin;
-
-
 create or replace function api.all_folders (name text, parent_ids int4[], is_root boolean, is_collection boolean, find text)
     returns setof api.folder as $$
     select * from entity.folder
@@ -73,6 +70,3 @@ $$ language plpgsql stable;
 
 comment on function api.folder_lineage (current_folder api.folder) is
     'Gets a list of folders representing the path from the folder up to the root of the hierarchy.';
-
-
-commit;

--- a/backend/src/api-fts-old.sql
+++ b/backend/src/api-fts-old.sql
@@ -1,5 +1,3 @@
-begin;
-
 
 -- drop type if exists aux.ranked_id;
 create type aux.ranked_id as (
@@ -112,6 +110,3 @@ $$ language sql stable rows 100 parallel safe;
 
 comment on function api.folder_author_search (folder api.folder, text text) is
     'Reads and enables pagination through all documents within a folder, filtered by a keyword search though the documents'' author.';
-
-
-commit;

--- a/backend/src/api-fts.sql
+++ b/backend/src/api-fts.sql
@@ -2,9 +2,6 @@
 -- Publicly exposed GraphQL functions
 -- regarding full-text search.
 
-begin;
-
-
 create or replace function aux.fts_ordered
     (fts_query tsquery
     , domain text
@@ -213,6 +210,3 @@ $$ language sql stable rows 100 parallel safe;
 
 comment on function api.folder_author_search (folder api.folder, text text) is
     'Reads and enables pagination through all documents within a folder, filtered by a keyword search though the documents'' author.';
-
-
-commit;

--- a/backend/src/api-fts.sql
+++ b/backend/src/api-fts.sql
@@ -38,7 +38,8 @@ create or replace function aux.fts_document_folder_limited
     returns table
         ( document api.document
         , distance float4
-        ) as $$
+        )
+    as $$
     select
         (document.id, document.type, document.schema, document.name, document.orderpos, document.attrs)::api.document as document,
         fts.distance
@@ -97,7 +98,7 @@ create or replace function aux.fts_document_folder_paginated
                 , domain
                 , language
                 , attribute_tests
-                    , "limit" + "offset" + 1
+                , "limit" + "offset" + 1
                 ) as f
             limit "limit"
             offset "offset";
@@ -114,7 +115,7 @@ create or replace function api.folder_fts_page
     , "limit" integer default 10
     , "offset" integer default 0
     )
-    returns api.fts_document_result_page as $$
+    returns api.document_result_page as $$
 
         with search_result as (
                 select *
@@ -131,7 +132,7 @@ create or replace function api.folder_fts_page
                 (select every(has_next_page) from search_result), false
             ) as has_next_page,
             array (
-            select row(number, distance, document)::api.fts_document_result
+            select row(number, distance, document)::api.document_result
                 from search_result
             ) as content
         ;
@@ -148,8 +149,8 @@ create or replace function api.folder_fts_page_pl
     , "limit" integer default 10
     , "offset" integer default 0
     )
-    returns api.fts_document_result_page as $$
-    declare res api.fts_document_result_page;
+    returns api.document_result_page as $$
+    declare res api.document_result_page;
 
     begin
         select
@@ -159,8 +160,8 @@ create or replace function api.folder_fts_page_pl
                 , false
                 ) as has_next_page,
             coalesce
-                ( array_agg (row (number, distance, document)::api.fts_document_result)
-                , array[]::api.fts_document_result[]
+                ( array_agg (row (number, distance, document)::api.document_result)
+                , array[]::api.document_result[]
                 ) as content
         into res
         from

--- a/backend/src/api-meta.sql
+++ b/backend/src/api-meta.sql
@@ -3,9 +3,6 @@
 -- regarding meta objects.
 
 
-begin;
-
-
 /*
 TODO: Quick and dirty pattern matching ahead. Needs more elaboration:
   - Escape special characters (% and _ for ilike)
@@ -526,6 +523,3 @@ $$ language sql stable;
 
 comment on function api.mask_exportmapping(mask api.mask) is
     'Gets the export mapping of this mask. Returns null if there is no such mapping.';
-
-
-commit;

--- a/backend/src/api-mutation.sql
+++ b/backend/src/api-mutation.sql
@@ -3,9 +3,6 @@
 -- demonstrating mutations
 
 
-begin;
-
-
 create or replace function api.update_document_attribute (id int4, key text, value text)
     returns api.document as $$
 
@@ -22,6 +19,3 @@ $$ language sql volatile;
 
 comment on function api.update_document_attribute (id int4, key text, value text) is
     'Updates an existing attribute of the document with the given id.';
-
-
-commit;

--- a/backend/src/api-node.sql
+++ b/backend/src/api-node.sql
@@ -3,9 +3,6 @@
 -- for generic access to nodes (that may be folders or documents)
 
 
-begin;
-
-
 create or replace function api.generic_node_by_id (id int4)
     returns api.generic_node as $$
     select node.id
@@ -37,5 +34,3 @@ $$ language sql stable;
 
 comment on function api.generic_node_as_folder (node api.generic_node) is
     'Gets the folder possibly represented by the generic node';
-
-commit;

--- a/backend/src/auxiliary.sql
+++ b/backend/src/auxiliary.sql
@@ -1,9 +1,6 @@
 
 -- Some auxiliary functions, that live in their own schema.
 
-begin;
-
-
 create schema if not exists aux;
 
 
@@ -170,6 +167,3 @@ create or replace function aux.nodetype_is_container (nodetype1 varchar)
           and nodetype.is_container
         )
 $$ language sql stable;
-
-
-commit;

--- a/backend/src/debug.sql
+++ b/backend/src/debug.sql
@@ -3,9 +3,6 @@
 -- Useful when examining the structure of the node table.
 
 
-begin;
-
-
 create or replace function debug.all_nodes (
         type text,
         schema text,
@@ -225,6 +222,3 @@ create or replace function debug.mediatum_node_as_document (node debug.mediatum_
     select * from entity.document
     where entity.document.id = node.id
 $$ language sql stable;
-
-
-commit;

--- a/backend/src/drop_all.sql
+++ b/backend/src/drop_all.sql
@@ -1,9 +1,4 @@
 
 -- Drop all schemas introduced specifically by this backend.
 
-
-begin;
-
 drop schema if exists aux, entity, api, debug, examine CASCADE;
-
-commit;

--- a/backend/src/entities.sql
+++ b/backend/src/entities.sql
@@ -3,9 +3,6 @@
 -- from mediaTUM's generic node table.
 
 
-begin;
-
-
 drop schema if exists entity CASCADE;
 create schema entity;
 
@@ -346,6 +343,3 @@ create or replace view entity.document_mask_value_list as
         ) as values
     from (select * from entity.document_mask_fields order by maskitem_orderpos) as q
     group by document_id, mask_name;
-
-
-commit;

--- a/backend/src/examine.sql
+++ b/backend/src/examine.sql
@@ -1,9 +1,6 @@
 
 -- Some queries for helping to examine the db structure.
 
-
-begin;
-
 create schema if not exists examine;
 
 
@@ -18,6 +15,3 @@ create or replace view examine.diss_attrs as
     from node where schema = 'diss'
     group by jsonb_object_keys (attrs)
     order by count (node.id) desc;
-
-
-commit;

--- a/backend/src/types.sql
+++ b/backend/src/types.sql
@@ -1,9 +1,6 @@
 
 -- Definitions of the types publicly exposed as GraphQL objects.
 
-
-begin;
-
 drop schema if exists api cascade;
 drop schema if exists debug cascade;
 
@@ -379,6 +376,3 @@ create type debug.mediatum_node as (
 	fulltext varchar,
 	subnode boolean
 );
-
-
-commit;

--- a/backend/src/types.sql
+++ b/backend/src/types.sql
@@ -295,33 +295,33 @@ comment on column api.attribute_test.extra is
     'Second comparison value, used if operator may take two values, like "ilike" or "daterange"';
 
 
-create type api.fts_document_result as (
+create type api.document_result as (
     number integer,
     distance float4,
     document api.document
 );
 
-comment on type api.fts_document_result is
+comment on type api.document_result is
     'A single result from a full text search, containing a document';
-comment on column api.fts_document_result.number is
+comment on column api.document_result.number is
     'Sequence number of this result';
-comment on column api.fts_document_result.distance is
+comment on column api.document_result.distance is
     'A measure of the relevance of this result with respect to the query expression; lower values means higher relevance';
-comment on column api.fts_document_result.document is
+comment on column api.document_result.document is
     'The resulting document';
 
 
-create type api.fts_document_result_page as (
+create type api.document_result_page as (
     "offset" integer,
     has_next_page boolean,
-    content api.fts_document_result[]
+    content api.document_result[]
 );
 
-comment on type api.fts_document_result_page is
+comment on type api.document_result_page is
     'A result page from a full text search of documents';
-comment on column api.fts_document_result_page.has_next_page is
+comment on column api.document_result_page.has_next_page is
     'Indicates whether there are more results after the current page';
-comment on column api.fts_document_result_page.content is
+comment on column api.document_result_page.content is
     'A list of document results from a full text search';
 
 

--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -291,7 +291,7 @@ queryFtsFolderCounts ftsQuery =
                         | id = ftsQuery.folder |> .id |> Folder.idToInt |> Present
                     }
                 )
-                (Graphql.Object.Folder.selection Dict.fromList
+                (Graphql.Object.Folder.selection identity
                     |> with
                         (Graphql.Object.Folder.ftsDocset
                             (\optionals ->
@@ -306,27 +306,33 @@ queryFtsFolderCounts ftsQuery =
                                             |> Present
                                 }
                             )
-                            (Graphql.Object.Docset.selection (::)
-                                |> with
-                                    (Graphql.Object.Docset.folderCount
-                                        folderCount
-                                        |> Graphql.Field.nonNullOrFail
-                                    )
-                                |> with
-                                    (Graphql.Object.Docset.subfolderCounts
-                                        identity
-                                        (Graphql.Object.FolderCountsConnection.selection identity
-                                            |> with
-                                                (Graphql.Object.FolderCountsConnection.nodes
-                                                    folderCount
-                                                )
-                                        )
-                                    )
-                            )
+                            folderAndSubfolderCounts
                             |> Graphql.Field.nonNullOrFail
                         )
                 )
                 |> Graphql.Field.nonNullOrFail
+            )
+
+
+folderAndSubfolderCounts : SelectionSet Folder.FolderCounts Graphql.Object.Docset
+folderAndSubfolderCounts =
+    Graphql.Object.Docset.selection
+        (\pair listOfPairs -> Dict.fromList (pair :: listOfPairs))
+        |> with
+            (Graphql.Object.Docset.folderCount
+                folderCount
+                |> Graphql.Field.nonNullOrFail
+            )
+        |> with
+            (Graphql.Object.Docset.subfolderCounts
+                identity
+                (Graphql.Object.FolderCountsConnection.selection
+                    identity
+                    |> with
+                        (Graphql.Object.FolderCountsConnection.nodes
+                            folderCount
+                        )
+                )
             )
 
 

--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -5,6 +5,7 @@ module Api exposing
     , makeQueryRequest
     , queryDocumentDetails
     , queryFolderDocumentsPage
+    , queryFolderFolderCounts
     , queryFtsFolderCounts
     , queryFtsPage
     , queryGenericNode
@@ -231,6 +232,28 @@ queryFolderDocumentsPage referencePage paginationPosition folderQuery =
                     }
                 )
                 (documentResultPage "nodesmall")
+                |> Graphql.Field.nonNullOrFail
+            )
+
+
+queryFolderFolderCounts :
+    Query.FolderQuery
+    -> SelectionSet FolderCounts Graphql.Operation.RootQuery
+queryFolderFolderCounts folderQuery =
+    Graphql.Query.selection identity
+        |> with
+            (Graphql.Query.allDocumentsDocset
+                (\optionals ->
+                    { optionals
+                        | folderId = folderQuery.folder |> .id |> Folder.idToInt |> Present
+                        , attributeTests =
+                            folderQuery.filters
+                                |> Query.filtersToAttributeTests
+                                |> Query.Attribute.testsAsGraphqlArgument
+                                |> Present
+                    }
+                )
+                folderAndSubfolderCounts
                 |> Graphql.Field.nonNullOrFail
             )
 

--- a/frontend/src/Article.elm
+++ b/frontend/src/Article.elm
@@ -148,6 +148,12 @@ update context msg model =
                     , NoReturn
                     )
 
+                Article.Directory.FolderCounts folderCounts ->
+                    ( model
+                    , Cmd.none
+                    , FolderCounts folderCounts
+                    )
+
                 Article.Directory.ShowDocument documentId ->
                     ( model
                     , Cmd.none

--- a/frontend/src/Article/Fts.elm
+++ b/frontend/src/Article/Fts.elm
@@ -36,8 +36,8 @@ type Return
 
 type alias Model =
     { pageResult : PageResult DocumentResult
-    , queryFolderCounts : Bool
     , iterator : Maybe Iterator.Model
+    , doQueryFolderCounts : Bool
     }
 
 
@@ -62,8 +62,8 @@ init context =
     let
         model =
             { pageResult = Page.initialPageResult
-            , queryFolderCounts = True
             , iterator = Nothing
+            , doQueryFolderCounts = True
             }
     in
     update
@@ -93,9 +93,9 @@ update context msg model =
         ApiResponseFtsPage result ->
             ( { model
                 | pageResult = Page.updatePageResultFromResult result model.pageResult
-                , queryFolderCounts = False
+                , doQueryFolderCounts = False
               }
-            , if model.queryFolderCounts then
+            , if model.doQueryFolderCounts then
                 Api.makeQueryRequest
                     ApiResponseFtsFolderCounts
                     (Api.queryFtsFolderCounts

--- a/frontend/src/Article/Fts.elm
+++ b/frontend/src/Article/Fts.elm
@@ -10,8 +10,8 @@ module Article.Fts exposing
 import Api
 import Article.Iterator as Iterator
 import Document exposing (Document, DocumentId)
+import DocumentResult exposing (DocumentResult)
 import Folder exposing (Folder, FolderCounts)
-import FtsDocumentResult exposing (FtsDocumentResult)
 import Graphql.Extra
 import Html exposing (Html)
 import Html.Attributes
@@ -35,21 +35,21 @@ type Return
 
 
 type alias Model =
-    { pageResult : PageResult FtsDocumentResult
+    { pageResult : PageResult DocumentResult
     , queryFolderCounts : Bool
     , iterator : Maybe Iterator.Model
     }
 
 
 type Msg
-    = ApiResponseFtsPage (Api.Response (Page FtsDocumentResult))
+    = ApiResponseFtsPage (Api.Response (Page DocumentResult))
     | ApiResponseFtsFolderCounts (Api.Response FolderCounts)
     | PickPosition Page.Position
     | SelectDocument DocumentId
     | IteratorMsg Iterator.Msg
 
 
-iteratorContext : Context -> Model -> Iterator.Context FtsDocumentResult
+iteratorContext : Context -> Model -> Iterator.Context DocumentResult
 iteratorContext context model =
     { folder = context.ftsQuery.folder
     , itemList = Maybe.Extra.unwrap [] Page.entries model.pageResult.page
@@ -175,7 +175,7 @@ view context model =
                     Just documentPage ->
                         viewResponse
                             PickPosition
-                            (viewPage (FtsDocumentResult.view SelectDocument))
+                            (viewPage (DocumentResult.view SelectDocument))
                             documentPage
                 , if model.pageResult.loading then
                     Icons.spinner

--- a/frontend/src/Article/Iterator.elm
+++ b/frontend/src/Article/Iterator.elm
@@ -11,7 +11,6 @@ module Article.Iterator exposing
 import Article.Details as Details
 import Document exposing (DocumentId)
 import Folder exposing (Folder)
-import FtsDocumentResult exposing (FtsDocumentResult)
 import Html exposing (Html)
 import Html.Attributes
 import Html.Events

--- a/frontend/src/DocumentResult.elm
+++ b/frontend/src/DocumentResult.elm
@@ -1,5 +1,5 @@
-module FtsDocumentResult exposing
-    ( FtsDocumentResult
+module DocumentResult exposing
+    ( DocumentResult
     , init
     , view
     )
@@ -8,14 +8,14 @@ import Document exposing (Document, DocumentId)
 import Html exposing (Html)
 
 
-type alias FtsDocumentResult =
+type alias DocumentResult =
     { number : Int
     , distance : Float
     , document : Document
     }
 
 
-init : Int -> Float -> Document -> FtsDocumentResult
+init : Int -> Float -> Document -> DocumentResult
 init number distance document =
     { number = number
     , distance = distance
@@ -23,9 +23,9 @@ init number distance document =
     }
 
 
-view : (DocumentId -> msg) -> FtsDocumentResult -> Html msg
-view clickMsg ftsDocumentResult =
+view : (DocumentId -> msg) -> DocumentResult -> Html msg
+view clickMsg documentResult =
     Document.view
         clickMsg
-        (Just ftsDocumentResult.number)
-        ftsDocumentResult.document
+        (Just documentResult.number)
+        documentResult.document


### PR DESCRIPTION
Changes:
- Listings of documents should use a uniform response structure, regardless of whether the query was a full text search or a mere listing of a directory. This relates to both the data types and the pagination method.
- A directory listing should display document counts on that folder and its sub-folders (just like FTS).
- Make FTS a root query, not a sub-query on a folder.
- Use latest version (4.3.3) of PostGraphile
- Clean-up transaction usage in SQL code.
