### PR TITLE
Update elm-graphql and all other Npm and Elm packages

### DIFF
--- a/frontend/elm.json
+++ b/frontend/elm.json
@@ -7,24 +7,26 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "Janiczek/cmd-extra": "1.0.0",
-            "dillonkearns/elm-graphql": "1.3.0",
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "Janiczek/cmd-extra": "1.1.0",
+            "dillonkearns/elm-graphql": "4.2.1",
+            "elm/browser": "1.0.1",
+            "elm/core": "1.0.2",
             "elm/html": "1.0.0",
-            "elm/http": "1.0.0",
-            "elm/json": "1.0.0",
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.3",
             "elm/regex": "1.0.0",
             "elm/svg": "1.0.1",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm-community/dict-extra": "2.4.0",
-            "elm-community/list-extra": "8.1.0",
+            "elm-community/list-extra": "8.2.0",
             "elm-community/maybe-extra": "5.0.0",
-            "mgold/elm-nonempty-list": "4.0.0"
+            "mgold/elm-nonempty-list": "4.0.1"
         },
         "indirect": {
             "Skinney/murmur3": "2.0.8",
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
             "elm/random": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "lukewestby/elm-string-interpolate": "1.0.3"

--- a/frontend/elm.json
+++ b/frontend/elm.json
@@ -21,7 +21,6 @@
             "elm-community/dict-extra": "2.4.0",
             "elm-community/list-extra": "8.1.0",
             "elm-community/maybe-extra": "5.0.0",
-            "elm-community/result-extra": "2.2.1",
             "mgold/elm-nonempty-list": "4.0.0"
         },
         "indirect": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5,36 +5,27 @@
   "requires": true,
   "dependencies": {
     "@dillonkearns/elm-graphql": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@dillonkearns/elm-graphql/-/elm-graphql-2.0.1.tgz",
-      "integrity": "sha512-8vzdlDg0LnMJYNJLX9ZIqQrtq+Wx6ed4Q66z2eRY8/ZKyM5meRbK3X1x+JIgk2TzIOK6c29Ung/u/UDnLEgTcQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@dillonkearns/elm-graphql/-/elm-graphql-3.4.0.tgz",
+      "integrity": "sha512-fgYQHP0AHsvEzcTHeClpuASuyPFHo7UAAZTc74uTZyCnVOnXGnTqIztbvvXTw4wu2NZ1tE/+hJzpbXSiXcTt4A==",
       "dev": true,
       "requires": {
         "encoding": "^0.1.12",
         "glob": "^7.1.2",
         "graphql-request": "^1.4.0",
-        "minimist": "^1.2.0",
         "request": "^2.83.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-regex": {
@@ -108,9 +99,9 @@
       "dev": true
     },
     "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
     "async-limiter": {
@@ -236,21 +227,22 @@
       }
     },
     "binary-extensions": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
     "binwrap": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/binwrap/-/binwrap-0.1.4.tgz",
-      "integrity": "sha1-yh94cDAiElGPoksHcm+cUKFcdVk=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/binwrap/-/binwrap-0.2.0.tgz",
+      "integrity": "sha512-HUspivC8zPE37KJQ0S4zsNHUpymzQBinmpdMoa+JwmB6Mi+p30ywVZJcillYpbQmiX2wLykaaDJxXmwZkbaZGA==",
       "dev": true,
       "requires": {
-        "request": "^2.81.0",
+        "mustache": "^2.3.0",
+        "request": "^2.87.0",
         "request-promise": "^4.2.0",
         "tar": "^2.2.1",
-        "unzip": "^0.1.11"
+        "unzip-stream": "^0.3.0"
       }
     },
     "block-stream": {
@@ -263,9 +255,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
       "dev": true
     },
     "brace-expansion": {
@@ -337,7 +329,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -348,9 +340,15 @@
         "supports-color": "^2.0.0"
       }
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "chokidar": {
       "version": "1.6.0",
-      "resolved": "http://registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz",
       "integrity": "sha1-kMMq1IApAddxPeUy3ChOlqY60Fg=",
       "dev": true,
       "requires": {
@@ -408,12 +406,6 @@
         "timers-ext": "0.1"
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -440,9 +432,9 @@
       "dev": true
     },
     "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
     "concat-map": {
@@ -490,6 +482,12 @@
         "which": "^1.2.9"
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
+    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -522,6 +520,16 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "default-gateway": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
+      "integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+      "dev": true,
+      "requires": {
+        "execa": "^0.10.0",
+        "ip-regex": "^2.1.0"
+      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -611,12 +619,12 @@
       "dev": true
     },
     "elm": {
-      "version": "0.19.0-bugfix2",
-      "resolved": "https://registry.npmjs.org/elm/-/elm-0.19.0-bugfix2.tgz",
-      "integrity": "sha512-kEbsC7SzTo6B2aq9ZEhdNZnqSehqVZvdXcm2FBKIAp1eRa1pxQr7VG1WXF5oC/XtYoQaQHVT3QMt5/PqA00ygg==",
+      "version": "0.19.0-bugfix6",
+      "resolved": "https://registry.npmjs.org/elm/-/elm-0.19.0-bugfix6.tgz",
+      "integrity": "sha512-nD/oK/nG26ULh94GREsILA9aQa3Gon+KKBmS0Z0MstywLWwrhuWKba8gfiIWLdnpQWHFIf+UsThk6Z71UWi6TQ==",
       "dev": true,
       "requires": {
-        "binwrap": "0.1.4"
+        "binwrap": "0.2.0"
       }
     },
     "elm-format": {
@@ -626,40 +634,25 @@
       "dev": true,
       "requires": {
         "binwrap": "^0.2.0"
-      },
-      "dependencies": {
-        "binwrap": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/binwrap/-/binwrap-0.2.0.tgz",
-          "integrity": "sha512-HUspivC8zPE37KJQ0S4zsNHUpymzQBinmpdMoa+JwmB6Mi+p30ywVZJcillYpbQmiX2wLykaaDJxXmwZkbaZGA==",
-          "dev": true,
-          "requires": {
-            "mustache": "^2.3.0",
-            "request": "^2.87.0",
-            "request-promise": "^4.2.0",
-            "tar": "^2.2.1",
-            "unzip-stream": "^0.3.0"
-          }
-        }
       }
     },
     "elm-live": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/elm-live/-/elm-live-3.1.0.tgz",
-      "integrity": "sha512-T3J8LtDfNb9+11af5ianmrQlVqibDKxL6qT7J3ibv3p008PEhDZ5CIZkQE5wnQiVNb+W8gvXw/RHiinWxYpmdA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/elm-live/-/elm-live-3.4.0.tgz",
+      "integrity": "sha512-t/pdd6yvFsft7cOysiV0ilmlE6TgCzDL6JQq+lG0TyL5ZjjTAdaYt5evJdyMliRfGY768zXKKQll4clM4VQyCA==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.1",
         "chokidar": "1.6.0",
         "commander": "2.17.1",
         "cross-spawn": "5.0.1",
-        "elm-serve": "0.2.0"
+        "elm-serve": "0.4.0"
       }
     },
     "elm-serve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/elm-serve/-/elm-serve-0.2.0.tgz",
-      "integrity": "sha512-DT/7ri/9RVHwo5LZgwNYZw0GzTO9A9ygVGZdh1HA/YQpHfbLHRuJs6C6khbvEd6Cg/2gt/QMjKZqHnZHMctuxA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/elm-serve/-/elm-serve-0.4.0.tgz",
+      "integrity": "sha512-NYXzzaJT/zw8v7jzDWGXuvX3/soj+5NTLHxX0n/T6DICbmyDj8kO7rlI2wSKs9UTNjXhZ7quFQEKcgcf/SZksw==",
       "dev": true,
       "requires": {
         "cli-color": "1.2.0",
@@ -667,8 +660,10 @@
         "connect-pushstate": "1.1.0",
         "finalhandler": "1.1.1",
         "http-proxy": "1.17.0",
+        "internal-ip": "3.0.1",
         "minimist": "1.2.0",
         "opn": "5.3.0",
+        "pem": "1.13.2",
         "serve-static": "1.13.2",
         "supervisor": "0.12.0",
         "url-parse": "1.4.3",
@@ -677,7 +672,7 @@
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
@@ -686,7 +681,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -708,14 +703,14 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.46",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+      "version": "0.10.49",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
+      "integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "next-tick": "^1.0.0"
       }
     },
     "es6-iterator": {
@@ -728,6 +723,12 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "es6-promisify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.1.tgz",
+      "integrity": "sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==",
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.1",
@@ -784,6 +785,36 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
       "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
       "dev": true
+    },
+    "execa": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -846,9 +877,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -878,7 +909,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -892,22 +923,28 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
-      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "dev": true,
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "^3.2.6"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
@@ -933,25 +970,14 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        }
       }
     },
     "fragment-cache": {
@@ -976,14 +1002,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
+      "integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -995,7 +1021,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1004,7 +1031,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1016,19 +1043,21 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1036,17 +1065,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1055,16 +1087,16 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1113,7 +1145,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1133,12 +1165,12 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -1163,7 +1195,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1175,6 +1208,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1189,6 +1223,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1196,19 +1231,21 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1220,40 +1257,41 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.12.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -1270,13 +1308,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1300,7 +1338,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1312,6 +1351,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1351,12 +1391,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -1386,18 +1426,19 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1412,7 +1453,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.7.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1433,6 +1474,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1452,6 +1494,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1463,17 +1506,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -1484,23 +1527,25 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1515,6 +1560,12 @@
         "mkdirp": ">=0.5 0",
         "rimraf": "2"
       }
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",
@@ -1565,9 +1616,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "graceful-readlink": {
@@ -1592,12 +1643,12 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
+        "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
       }
     },
@@ -1672,7 +1723,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -1727,6 +1778,28 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "internal-ip": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
+      "integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+      "dev": true,
+      "requires": {
+        "default-gateway": "^2.6.0",
+        "ipaddr.js": "^1.5.2"
+      }
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -1861,6 +1934,12 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -1880,9 +1959,9 @@
       "dev": true
     },
     "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
@@ -1898,14 +1977,6 @@
       "dev": true,
       "requires": {
         "isarray": "1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        }
       }
     },
     "isstream": {
@@ -1927,9 +1998,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stringify-safe": {
@@ -1966,9 +2037,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
@@ -1999,21 +2070,22 @@
         "object-visit": "^1.0.0"
       }
     },
-    "match-stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
-      "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "dev": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "dev": true,
       "requires": {
-        "buffers": "~0.1.1",
-        "readable-stream": "~1.0.0"
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       }
-    },
-    "math-random": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-      "dev": true
     },
     "memoizee": {
       "version": "0.4.14",
@@ -2059,18 +2131,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.36.0"
+        "mime-db": "1.40.0"
       }
     },
     "minimatch": {
@@ -2084,7 +2156,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -2111,7 +2183,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -2131,9 +2203,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true,
       "optional": true
     },
@@ -2176,21 +2248,21 @@
         }
       }
     },
-    "natives": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-      "dev": true
-    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
     "node-fetch": {
       "version": "2.1.2",
-      "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
       "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
       "dev": true
     },
@@ -2201,6 +2273,15 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
       }
     },
     "oauth-sign": {
@@ -2295,17 +2376,23 @@
     },
     "opn": {
       "version": "5.3.0",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
       }
     },
-    "over": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
-      "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg=",
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "parse-glob": {
@@ -2321,9 +2408,9 @@
       }
     },
     "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
     "pascalcase": {
@@ -2337,6 +2424,24 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "pem": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.13.2.tgz",
+      "integrity": "sha512-MPJWuEb/r6AG+GpZi2JnfNtGAZDeL/8+ERKwXEWRuST5i+4lq/Uy36B352OWIUSPQGH+HR1HEDcIDi+8cKxXNg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^6.0.0",
+        "md5": "^2.2.1",
+        "os-tmpdir": "^1.0.1",
+        "which": "^1.3.1"
+      }
     },
     "performance-now": {
       "version": "2.1.0",
@@ -2369,27 +2474,15 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
       "dev": true
     },
-    "pullstream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
-      "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
-      "dev": true,
-      "requires": {
-        "over": ">= 0.0.5 < 1",
-        "readable-stream": "~1.0.31",
-        "setimmediate": ">= 1.0.2 < 2",
-        "slice-stream": ">= 1.0.0 < 2"
-      }
-    },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "qs": {
@@ -2399,15 +2492,15 @@
       "dev": true
     },
     "querystringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
       "dev": true
     },
     "randomatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "dev": true,
       "requires": {
         "is-number": "^4.0.0",
@@ -2436,15 +2529,18 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "1.0.34",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -2699,12 +2795,6 @@
             }
           }
         },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -2736,30 +2826,6 @@
             "regex-not": "^1.0.0",
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2830,24 +2896,24 @@
       }
     },
     "request-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.4.tgz",
+      "integrity": "sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
       "dev": true,
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "^4.17.11"
       }
     },
     "requires-port": {
@@ -2869,12 +2935,12 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {
@@ -2896,6 +2962,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true
     },
     "send": {
@@ -2954,12 +3026,6 @@
         }
       }
     },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
-    },
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
@@ -2981,14 +3047,11 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "slice-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
-      "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~1.0.31"
-      }
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -3133,9 +3196,9 @@
       }
     },
     "sshpk": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
-      "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -3183,19 +3246,28 @@
       "dev": true
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "supervisor": {
       "version": "0.12.0",
@@ -3280,6 +3352,14 @@
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
       }
     },
     "traverse": {
@@ -3382,54 +3462,11 @@
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
-        }
-      }
-    },
-    "unzip": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
-      "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
-      "dev": true,
-      "requires": {
-        "binary": ">= 0.3.0 < 1",
-        "fstream": ">= 0.1.30 < 1",
-        "match-stream": ">= 0.0.2 < 1",
-        "pullstream": ">= 0.4.1 < 1",
-        "readable-stream": "~1.0.31",
-        "setimmediate": ">= 1.0.1 < 2"
-      },
-      "dependencies": {
-        "fstream": {
-          "version": "0.1.31",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-          "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "~3.0.2",
-            "inherits": "~2.0.0",
-            "mkdirp": "0.5",
-            "rimraf": "2"
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true,
-          "requires": {
-            "natives": "^1.1.0"
-          }
         }
       }
     },
@@ -3441,6 +3478,15 @@
       "requires": {
         "binary": "^0.3.0",
         "mkdirp": "^0.5.1"
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -3490,7 +3536,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
       "dev": true
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,10 +32,10 @@
   },
   "homepage": "https://github.com/ThomasWeiser/mediatum-view#readme",
   "devDependencies": {
-    "@dillonkearns/elm-graphql": "^2.0.1",
-    "elm": "^0.19.0-bugfix2",
+    "@dillonkearns/elm-graphql": "^3.4.0",
+    "elm": "^0.19.0-bugfix6",
     "elm-format": "^0.8.1",
-    "elm-live": "^3.1.0",
-    "rimraf": "^2.6.2"
+    "elm-live": "^3.4.0",
+    "rimraf": "^2.6.3"
   }
 }

--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -20,7 +20,6 @@ import DocumentResult exposing (DocumentResult)
 import Folder exposing (Folder, FolderCounts, FolderId)
 import GenericNode exposing (GenericNode)
 import Graphql.Extra
-import Graphql.Field
 import Graphql.Http
 import Graphql.Mutation
 import Graphql.Object
@@ -42,7 +41,7 @@ import Graphql.Operation
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.Query
 import Graphql.Scalar
-import Graphql.SelectionSet exposing (SelectionSet, with)
+import Graphql.SelectionSet as SelectionSet exposing (SelectionSet)
 import Json.Decode exposing (Decoder)
 import List.Nonempty exposing (Nonempty)
 import Maybe.Extra
@@ -96,32 +95,32 @@ makeMutationRequest tagger selectionSet =
 
 queryToplevelFolder : SelectionSet (List ( Folder, List Folder )) Graphql.Operation.RootQuery
 queryToplevelFolder =
-    Graphql.Query.selection identity
-        |> with
+    SelectionSet.succeed identity
+        |> SelectionSet.with
             (Graphql.Query.allFolders
                 (\optionals ->
                     { optionals
                         | isRoot = Present True
                     }
                 )
-                (Graphql.Object.FoldersConnection.selection identity
-                    |> with (Graphql.Object.FoldersConnection.nodes folderNodeWithSubfolders)
+                (SelectionSet.succeed identity
+                    |> SelectionSet.with (Graphql.Object.FoldersConnection.nodes folderNodeWithSubfolders)
                 )
             )
 
 
 querySubfolder : List FolderId -> SelectionSet (List Folder) Graphql.Operation.RootQuery
 querySubfolder folderIds =
-    Graphql.Query.selection identity
-        |> with
+    SelectionSet.succeed identity
+        |> SelectionSet.with
             (Graphql.Query.allFolders
                 (\optionals ->
                     { optionals
                         | parentIds = Present <| List.map (Folder.idToInt >> Just) folderIds
                     }
                 )
-                (Graphql.Object.FoldersConnection.selection identity
-                    |> with (Graphql.Object.FoldersConnection.nodes folderNode)
+                (SelectionSet.succeed identity
+                    |> SelectionSet.with (Graphql.Object.FoldersConnection.nodes folderNode)
                 )
             )
 
@@ -141,30 +140,27 @@ queryGenericNode nodeId =
                 ( Nothing, Nothing ) ->
                     GenericNode.IsNeither
     in
-    Graphql.Query.selection identity
-        |> with
-            (Graphql.Query.genericNodeById
-                (\optionals ->
-                    { optionals
-                        | id = Present nodeId
-                    }
-                )
-                (Graphql.Object.GenericNode.selection constructor
-                    |> with (Graphql.Object.GenericNode.asFolder folderLineage)
-                    |> with (Graphql.Object.GenericNode.asDocument (documentNode "nodebig"))
-                )
-                |> Graphql.Field.nonNullOrFail
-            )
+    Graphql.Query.genericNodeById
+        (\optionals ->
+            { optionals
+                | id = Present nodeId
+            }
+        )
+        (SelectionSet.succeed constructor
+            |> SelectionSet.with (Graphql.Object.GenericNode.asFolder folderLineage)
+            |> SelectionSet.with (Graphql.Object.GenericNode.asDocument (documentNode "nodebig"))
+        )
+        |> SelectionSet.nonNullOrFail
 
 
 folderNode : SelectionSet Folder Graphql.Object.Folder
 folderNode =
-    Graphql.Object.Folder.selection Folder.init
-        |> with (Graphql.Object.Folder.id |> Graphql.Field.nonNullOrFail)
-        |> with Graphql.Object.Folder.parentId
-        |> with (Graphql.Object.Folder.name |> Graphql.Field.nonNullOrFail)
-        |> with (Graphql.Object.Folder.isCollection |> Graphql.Field.nonNullOrFail)
-        |> with (Graphql.Object.Folder.numSubfolder |> Graphql.Field.nonNullOrFail)
+    SelectionSet.succeed Folder.init
+        |> SelectionSet.with (Graphql.Object.Folder.id |> SelectionSet.nonNullOrFail)
+        |> SelectionSet.with Graphql.Object.Folder.parentId
+        |> SelectionSet.with (Graphql.Object.Folder.name |> SelectionSet.nonNullOrFail)
+        |> SelectionSet.with (Graphql.Object.Folder.isCollection |> SelectionSet.nonNullOrFail)
+        |> SelectionSet.with (Graphql.Object.Folder.numSubfolder |> SelectionSet.nonNullOrFail)
 
 
 folderNodeWithSubfolders : SelectionSet ( Folder, List Folder ) Graphql.Object.Folder
@@ -176,29 +172,29 @@ folderNodeWithSubfolders =
             , subfolder
             )
     in
-    Graphql.Object.Folder.selection constructor
-        |> with (Graphql.Object.Folder.id |> Graphql.Field.nonNullOrFail)
-        |> with Graphql.Object.Folder.parentId
-        |> with (Graphql.Object.Folder.name |> Graphql.Field.nonNullOrFail)
-        |> with (Graphql.Object.Folder.isCollection |> Graphql.Field.nonNullOrFail)
-        |> with (Graphql.Object.Folder.numSubfolder |> Graphql.Field.nonNullOrFail)
-        |> with
+    SelectionSet.succeed constructor
+        |> SelectionSet.with (Graphql.Object.Folder.id |> SelectionSet.nonNullOrFail)
+        |> SelectionSet.with Graphql.Object.Folder.parentId
+        |> SelectionSet.with (Graphql.Object.Folder.name |> SelectionSet.nonNullOrFail)
+        |> SelectionSet.with (Graphql.Object.Folder.isCollection |> SelectionSet.nonNullOrFail)
+        |> SelectionSet.with (Graphql.Object.Folder.numSubfolder |> SelectionSet.nonNullOrFail)
+        |> SelectionSet.with
             (Graphql.Object.Folder.subfolders identity
-                (Graphql.Object.FoldersConnection.selection identity
-                    |> with (Graphql.Object.FoldersConnection.nodes folderNode)
+                (SelectionSet.succeed identity
+                    |> SelectionSet.with (Graphql.Object.FoldersConnection.nodes folderNode)
                 )
             )
 
 
 folderLineage : SelectionSet (Nonempty Folder) Graphql.Object.Folder
 folderLineage =
-    Graphql.Object.Folder.selection identity
-        |> with
+    SelectionSet.succeed identity
+        |> SelectionSet.with
             (Graphql.Object.Folder.lineage
                 folderNode
-                |> Graphql.Field.nonNullOrFail
-                |> Graphql.Field.nonNullElementsOrFail
-                |> Graphql.Field.mapOrFail
+                |> SelectionSet.nonNullOrFail
+                |> SelectionSet.nonNullElementsOrFail
+                |> SelectionSet.mapOrFail
                     (List.Nonempty.fromList
                         >> Result.fromMaybe "Lineage needs at least one folder"
                     )
@@ -211,8 +207,8 @@ queryFolderDocumentsPage :
     -> Query.FolderQuery
     -> SelectionSet (Pagination.Offset.Page.Page DocumentResult) Graphql.Operation.RootQuery
 queryFolderDocumentsPage referencePage paginationPosition folderQuery =
-    Graphql.Query.selection identity
-        |> with
+    SelectionSet.succeed identity
+        |> SelectionSet.with
             (Graphql.Query.allDocumentsPage
                 (\optionals ->
                     { optionals
@@ -232,7 +228,7 @@ queryFolderDocumentsPage referencePage paginationPosition folderQuery =
                     }
                 )
                 (documentResultPage "nodesmall")
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
 
 
@@ -240,8 +236,8 @@ queryFolderFolderCounts :
     Query.FolderQuery
     -> SelectionSet FolderCounts Graphql.Operation.RootQuery
 queryFolderFolderCounts folderQuery =
-    Graphql.Query.selection identity
-        |> with
+    SelectionSet.succeed identity
+        |> SelectionSet.with
             (Graphql.Query.allDocumentsDocset
                 (\optionals ->
                     { optionals
@@ -254,7 +250,7 @@ queryFolderFolderCounts folderQuery =
                     }
                 )
                 folderAndSubfolderCounts
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
 
 
@@ -264,8 +260,8 @@ queryFtsPage :
     -> Query.FtsQuery
     -> SelectionSet (Pagination.Offset.Page.Page DocumentResult) Graphql.Operation.RootQuery
 queryFtsPage referencePage paginationPosition ftsQuery =
-    Graphql.Query.selection identity
-        |> with
+    SelectionSet.succeed identity
+        |> SelectionSet.with
             (Graphql.Query.ftsDocumentsPage
                 (\optionals ->
                     { optionals
@@ -288,7 +284,7 @@ queryFtsPage referencePage paginationPosition ftsQuery =
                     }
                 )
                 (documentResultPage "nodesmall")
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
 
 
@@ -296,8 +292,8 @@ queryFtsFolderCounts :
     Query.FtsQuery
     -> SelectionSet FolderCounts Graphql.Operation.RootQuery
 queryFtsFolderCounts ftsQuery =
-    Graphql.Query.selection identity
-        |> with
+    SelectionSet.succeed identity
+        |> SelectionSet.with
             (Graphql.Query.ftsDocumentsDocset
                 (\optionals ->
                     { optionals
@@ -313,25 +309,24 @@ queryFtsFolderCounts ftsQuery =
                     }
                 )
                 folderAndSubfolderCounts
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
 
 
 folderAndSubfolderCounts : SelectionSet Folder.FolderCounts Graphql.Object.Docset
 folderAndSubfolderCounts =
-    Graphql.Object.Docset.selection
+    SelectionSet.succeed
         (\pair listOfPairs -> Dict.fromList (pair :: listOfPairs))
-        |> with
+        |> SelectionSet.with
             (Graphql.Object.Docset.folderCount
                 folderCount
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
-        |> with
+        |> SelectionSet.with
             (Graphql.Object.Docset.subfolderCounts
                 identity
-                (Graphql.Object.FolderCountsConnection.selection
-                    identity
-                    |> with
+                (SelectionSet.succeed identity
+                    |> SelectionSet.with
                         (Graphql.Object.FolderCountsConnection.nodes
                             folderCount
                         )
@@ -341,54 +336,48 @@ folderAndSubfolderCounts =
 
 folderCount : SelectionSet ( FolderId, Int ) Graphql.Object.FolderCount
 folderCount =
-    Graphql.Object.FolderCount.selection (\a b -> ( a, b ))
-        |> with
+    SelectionSet.succeed (\a b -> ( a, b ))
+        |> SelectionSet.with
             (Graphql.Object.FolderCount.folderId
-                |> Graphql.Field.nonNullOrFail
-                |> Graphql.Field.map Folder.idFromInt
+                |> SelectionSet.nonNullOrFail
+                |> SelectionSet.map Folder.idFromInt
             )
-        |> with
+        |> SelectionSet.with
             (Graphql.Object.FolderCount.count
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
 
 
-
-{-
-   queryAuthorSearch :
-       Maybe (Pagination.Relay.Page.Page Document)
-       -> Pagination.Relay.Pagination.Position
-       -> FolderId
-       -> String
-       -> SelectionSet (Pagination.Relay.Page.Page Document) Graphql.Operation.RootQuery
-   queryAuthorSearch referencePage paginationPosition folderId searchString =
-       Graphql.Query.selection identity
-           |> with
-               (Graphql.Query.authorSearch
-                   ((\optionals ->
-                       { optionals
-                           | text = Present searchString
-                       }
-                    )
-                       >> Pagination.Relay.Pagination.paginationArguments
-                           pageSize
-                           referencePage
-                           paginationPosition
-                   )
-                   (Connection.connection
-                       graphqlDocumentObjects
-                       (documentNode "nodesmall")
-                   )
-               )
--}
+queryAuthorSearch :
+    Maybe (Pagination.Relay.Page.Page Document)
+    -> Pagination.Relay.Pagination.Position
+    -> FolderId
+    -> String
+    -> SelectionSet (Pagination.Relay.Page.Page Document) Graphql.Operation.RootQuery
+queryAuthorSearch referencePage paginationPosition folderId searchString =
+    Graphql.Query.authorSearch
+        ((\optionals ->
+            { optionals
+                | text = Present searchString
+            }
+         )
+            >> Pagination.Relay.Pagination.paginationArguments
+                pageSize
+                referencePage
+                paginationPosition
+        )
+        (Connection.connection
+            graphqlDocumentObjects
+            (documentNode "nodesmall")
+        )
 
 
 queryDocumentDetails :
     DocumentId
     -> SelectionSet (Maybe Document) Graphql.Operation.RootQuery
 queryDocumentDetails documentId =
-    Graphql.Query.selection identity
-        |> with
+    SelectionSet.succeed identity
+        |> SelectionSet.with
             (Graphql.Query.documentById
                 (\optionals ->
                     { optionals
@@ -405,8 +394,8 @@ updateDocumentAttribute :
     -> String
     -> SelectionSet (Maybe Document) Graphql.Operation.RootMutation
 updateDocumentAttribute documentId key value =
-    Graphql.Mutation.selection Maybe.Extra.join
-        |> with
+    SelectionSet.succeed Maybe.Extra.join
+        |> SelectionSet.with
             (Graphql.Mutation.updateDocumentAttribute
                 { input =
                     { clientMutationId = Absent
@@ -415,8 +404,8 @@ updateDocumentAttribute documentId key value =
                     , value = Present value
                     }
                 }
-                (Graphql.Object.UpdateDocumentAttributePayload.selection identity
-                    |> with
+                (SelectionSet.succeed identity
+                    |> SelectionSet.with
                         (Graphql.Object.UpdateDocumentAttributePayload.document
                             (documentNode "nodebig")
                         )
@@ -428,70 +417,70 @@ documentResultPage :
     String
     -> SelectionSet (Pagination.Offset.Page.Page DocumentResult) Graphql.Object.DocumentResultPage
 documentResultPage maskName =
-    Graphql.Object.DocumentResultPage.selection Pagination.Offset.Page.Page
-        |> with
+    SelectionSet.succeed Pagination.Offset.Page.Page
+        |> SelectionSet.with
             (Graphql.Object.DocumentResultPage.offset
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
-        |> with
+        |> SelectionSet.with
             (Graphql.Object.DocumentResultPage.hasNextPage
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
-        |> with
+        |> SelectionSet.with
             (Graphql.Object.DocumentResultPage.content
                 (documentResult maskName)
-                |> Graphql.Field.nonNullOrFail
-                |> Graphql.Field.nonNullElementsOrFail
+                |> SelectionSet.nonNullOrFail
+                |> SelectionSet.nonNullElementsOrFail
             )
 
 
 documentResult : String -> SelectionSet DocumentResult Graphql.Object.DocumentResult
 documentResult maskName =
-    Graphql.Object.DocumentResult.selection DocumentResult.init
-        |> with
+    SelectionSet.succeed DocumentResult.init
+        |> SelectionSet.with
             (Graphql.Object.DocumentResult.number
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
-        |> with
+        |> SelectionSet.with
             (Graphql.Object.DocumentResult.distance
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
-        |> with
+        |> SelectionSet.with
             (Graphql.Object.DocumentResult.document
                 (documentNode maskName)
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
 
 
 documentNode : String -> SelectionSet Document Graphql.Object.Document
 documentNode maskName =
-    Graphql.Object.Document.selection Document.init
-        |> with
+    SelectionSet.succeed Document.init
+        |> SelectionSet.with
             (Graphql.Object.Document.id
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
-        |> with
+        |> SelectionSet.with
             (Graphql.Object.Document.metadatatype
-                (Graphql.Object.Metadatatype.selection identity
-                    |> with
+                (SelectionSet.succeed identity
+                    |> SelectionSet.with
                         (Graphql.Object.Metadatatype.longname
-                            |> Graphql.Field.nonNullOrFail
+                            |> SelectionSet.nonNullOrFail
                         )
                 )
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
-        |> with
+        |> SelectionSet.with
             (Graphql.Object.Document.name
-                |> Graphql.Field.nonNullOrFail
+                |> SelectionSet.nonNullOrFail
             )
-        |> with
+        |> SelectionSet.with
             (Graphql.Object.Document.valuesByMask
                 (\optionals ->
                     { optionals
                         | maskName = Present maskName
                     }
                 )
-                |> Graphql.Field.map mapJsonToAttributes
+                |> SelectionSet.map mapJsonToAttributes
             )
 
 
@@ -521,14 +510,11 @@ decoderAttributeList =
 
 graphqlDocumentObjects : Connection.GraphqlObjects {} Graphql.Object.DocumentsConnection Graphql.Object.DocumentsEdge Graphql.Object.Document Graphql.Object.PageInfo Graphql.Scalar.Cursor Document
 graphqlDocumentObjects =
-    { connectionSelection = Graphql.Object.DocumentsConnection.selection
-    , totalCount = Graphql.Object.DocumentsConnection.totalCount
+    { totalCount = Graphql.Object.DocumentsConnection.totalCount
     , pageInfo = Graphql.Object.DocumentsConnection.pageInfo
     , edges = Graphql.Object.DocumentsConnection.edges
-    , edgeSelection = Graphql.Object.DocumentsEdge.selection
     , cursor = Graphql.Object.DocumentsEdge.cursor
     , node = Graphql.Object.DocumentsEdge.node
-    , pageInfoSelection = Graphql.Object.PageInfo.selection
     , hasNextPage = Graphql.Object.PageInfo.hasNextPage
     , hasPreviousPage = Graphql.Object.PageInfo.hasPreviousPage
     }

--- a/frontend/src/Graphql/Extra.elm
+++ b/frontend/src/Graphql/Extra.elm
@@ -7,10 +7,11 @@ module Graphql.Extra exposing
 import Graphql.Http
 import Graphql.Http.GraphqlError
 import Http
+import Json.Decode
 
 
 type StrippedError
-    = HttpError Http.Error
+    = HttpError Graphql.Http.HttpError
     | GraphqlError (List Graphql.Http.GraphqlError.GraphqlError)
 
 
@@ -31,34 +32,34 @@ errorToString error =
             httpErrorToString httpError
 
         GraphqlError graphqlError ->
-            graphqErrorToString graphqlError
+            graphqlErrorToString graphqlError
 
 
-httpErrorToString : Http.Error -> String
+httpErrorToString : Graphql.Http.HttpError -> String
 httpErrorToString error =
     case error of
-        Http.BadUrl url ->
+        Graphql.Http.BadUrl url ->
             "Bad Url: \"" ++ url ++ "\""
 
-        Http.Timeout ->
+        Graphql.Http.Timeout ->
             "Timeout"
 
-        Http.NetworkError ->
+        Graphql.Http.NetworkError ->
             "NetworkError"
 
-        Http.BadStatus response ->
+        Graphql.Http.BadStatus metadata payload ->
             "BadStatus: "
-                ++ String.fromInt response.status.code
+                ++ String.fromInt metadata.statusCode
                 ++ " ("
-                ++ response.status.message
+                ++ metadata.statusText
                 ++ ")"
 
-        Http.BadPayload explanation _ ->
-            "BadPayload: " ++ explanation
+        Graphql.Http.BadPayload jsonDecodeError ->
+            "BadPayload: " ++ Json.Decode.errorToString jsonDecodeError
 
 
-graphqErrorToString : List Graphql.Http.GraphqlError.GraphqlError -> String
-graphqErrorToString errorList =
+graphqlErrorToString : List Graphql.Http.GraphqlError.GraphqlError -> String
+graphqlErrorToString errorList =
     String.join
         ", "
         (List.map .message errorList)

--- a/frontend/src/Pagination/Relay/Connection.elm
+++ b/frontend/src/Pagination/Relay/Connection.elm
@@ -8,8 +8,7 @@ module Pagination.Relay.Connection exposing
     , pageInfo
     )
 
-import Graphql.Field
-import Graphql.SelectionSet exposing (SelectionSet, with)
+import Graphql.SelectionSet as SelectionSet exposing (SelectionSet)
 
 
 type alias Connection cursorScalar nodeType =
@@ -33,24 +32,15 @@ type alias PageInfo =
 
 type alias GraphqlObjects graphqlObjectsRecord connectionObject edgeObject nodeObject pageInfoObject cursorScalar nodeType =
     { graphqlObjectsRecord
-        | connectionSelection :
-            (PageInfo -> List (Edge cursorScalar nodeType) -> Int -> Connection cursorScalar nodeType)
-            -> SelectionSet (PageInfo -> List (Edge cursorScalar nodeType) -> Int -> Connection cursorScalar nodeType) connectionObject
-        , pageInfo :
+        | pageInfo :
             SelectionSet PageInfo pageInfoObject
-            -> Graphql.Field.Field PageInfo connectionObject
-        , totalCount : Graphql.Field.Field (Maybe Int) connectionObject
-        , edges : SelectionSet (Edge cursorScalar nodeType) edgeObject -> Graphql.Field.Field (List (Edge cursorScalar nodeType)) connectionObject
-        , edgeSelection :
-            (cursorScalar -> nodeType -> Edge cursorScalar nodeType)
-            -> SelectionSet (cursorScalar -> nodeType -> Edge cursorScalar nodeType) edgeObject
-        , cursor : Graphql.Field.Field (Maybe cursorScalar) edgeObject
-        , node : SelectionSet nodeType nodeObject -> Graphql.Field.Field nodeType edgeObject
-        , pageInfoSelection :
-            (Bool -> Bool -> PageInfo)
-            -> SelectionSet (Bool -> Bool -> PageInfo) pageInfoObject
-        , hasNextPage : Graphql.Field.Field Bool pageInfoObject
-        , hasPreviousPage : Graphql.Field.Field Bool pageInfoObject
+            -> SelectionSet PageInfo connectionObject
+        , totalCount : SelectionSet (Maybe Int) connectionObject
+        , edges : SelectionSet (Edge cursorScalar nodeType) edgeObject -> SelectionSet (List (Edge cursorScalar nodeType)) connectionObject
+        , cursor : SelectionSet (Maybe cursorScalar) edgeObject
+        , node : SelectionSet nodeType nodeObject -> SelectionSet nodeType edgeObject
+        , hasNextPage : SelectionSet Bool pageInfoObject
+        , hasPreviousPage : SelectionSet Bool pageInfoObject
     }
 
 
@@ -64,10 +54,10 @@ connection :
     -> SelectionSet nodeType nodeObject
     -> SelectionSet (Connection cursorScalar nodeType) connectionObject
 connection graphqlObjects nodeSelectionSet =
-    graphqlObjects.connectionSelection Connection
-        |> with (graphqlObjects.pageInfo (pageInfo graphqlObjects))
-        |> with (graphqlObjects.edges (edge graphqlObjects nodeSelectionSet))
-        |> with (graphqlObjects.totalCount |> Graphql.Field.nonNullOrFail)
+    SelectionSet.succeed Connection
+        |> SelectionSet.with (graphqlObjects.pageInfo (pageInfo graphqlObjects))
+        |> SelectionSet.with (graphqlObjects.edges (edge graphqlObjects nodeSelectionSet))
+        |> SelectionSet.with (graphqlObjects.totalCount |> SelectionSet.nonNullOrFail)
 
 
 edge :
@@ -75,15 +65,15 @@ edge :
     -> SelectionSet nodeType nodeObject
     -> SelectionSet (Edge cursorScalar nodeType) edgeObject
 edge graphqlObjects nodeSelectionSet =
-    graphqlObjects.edgeSelection Edge
-        |> with (graphqlObjects.cursor |> Graphql.Field.nonNullOrFail)
-        |> with (graphqlObjects.node nodeSelectionSet)
+    SelectionSet.succeed Edge
+        |> SelectionSet.with (graphqlObjects.cursor |> SelectionSet.nonNullOrFail)
+        |> SelectionSet.with (graphqlObjects.node nodeSelectionSet)
 
 
 pageInfo :
     GraphqlObjects graphqlObjectsRecord connectionObject edgeObject nodeObject pageInfoObject cursorScalar nodeType
     -> SelectionSet PageInfo pageInfoObject
 pageInfo graphqlObjects =
-    graphqlObjects.pageInfoSelection PageInfo
-        |> with graphqlObjects.hasNextPage
-        |> with graphqlObjects.hasPreviousPage
+    SelectionSet.succeed PageInfo
+        |> SelectionSet.with graphqlObjects.hasNextPage
+        |> SelectionSet.with graphqlObjects.hasPreviousPage


### PR DESCRIPTION
Update `elm-graphql` and all other Npm and Elm packages

Major updates:
- Npm package `@dillonkearns/elm-graphql`: 2.0.1 -> 3.4.0
- Elm package `dillonkearns/elm-graphql`: 1.x -> 4.x
- Elm package `elm/http`: 1.x -> 2.x
