### PR TITLE
Websearch query syntax

### DIFF
--- a/backend/src/sql/api-facets.sql
+++ b/backend/src/sql/api-facets.sql
@@ -80,7 +80,7 @@ create or replace function api.fts_documents_docset
     begin  
         return aux.fts_documents_tsquery_docset
           ( folder_id
-          , plainto_tsquery ('english_german'::regconfig, text)
+          , aux.custom_to_tsquery (text)
           , attribute_tests
           );
     end;

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -95,7 +95,7 @@ create or replace function aux.fts_documents_paginated
                 , (count(*) over ()) > "limit" + "offset"
             from aux.fts_documents_limited
                 ( folder_id
-                , plainto_tsquery ('english_german'::regconfig, text)
+                , aux.custom_to_tsquery (text)
                 , attribute_tests
                 , sorting
                 , "limit" + "offset" + 1
@@ -196,9 +196,7 @@ create or replace function api.author_search (folder_id int4, text text)
         node.name,
         node.orderpos,
         node.attrs
-    from to_tsquery ('german', text) as tsq, -- needs a wellformed tsquery string
-         -- to_tsquery ('german', text || ':*') as tsq, -- works only for a single word (i.e. without spaces)
-         -- plainto_tsquery ('german', text) as tsq, -- no prefix search
+    from aux.custom_to_tsquery (text) as tsq,
          mediatum.node
     where aux.test_node_lineage (folder_id, node.id)
       and mediatum.to_tsvector_safe (

--- a/backend/src/sql/auxiliary.sql
+++ b/backend/src/sql/auxiliary.sql
@@ -46,7 +46,15 @@ $$ language plpgsql stable;
 create or replace function aux.custom_to_tsquery (query text)
     returns tsquery as $$
     begin
-        return plainto_tsquery ('english_german'::regconfig, query);
+        -- Check the availability of the function "websearch_to_tsquery",
+        -- which has been introduced in PostgreSQL 11.
+        -- If running an older version of PostgreSQL we fall back to "plainto_tsquery".
+        if exists(select from pg_proc where proname = 'websearch_to_tsquery')
+        then
+            return websearch_to_tsquery ('english_german'::regconfig, query);
+        else
+            return plainto_tsquery ('english_german'::regconfig, query);
+        end if;
     end;
 $$ language plpgsql immutable;
 

--- a/backend/src/sql/auxiliary.sql
+++ b/backend/src/sql/auxiliary.sql
@@ -43,6 +43,14 @@ create or replace function aux.node_children (parent_node_id int4)
 $$ language plpgsql stable;
 
 
+create or replace function aux.custom_to_tsquery (query text)
+    returns tsquery as $$
+    begin
+        return plainto_tsquery ('english_german'::regconfig, query);
+    end;
+$$ language plpgsql immutable;
+
+
 create or replace function aux.jsonb_filter (obj jsonb, keys text[])
     returns jsonb as $$
     declare result jsonb := '{}'::jsonb;
@@ -87,7 +95,7 @@ create or replace function aux.jsonb_test_list (obj jsonb, tests api.attribute_t
                         return false;
                     end if;
                 when 'simplefts' then
-                    if not to_tsvector('simple', key_value) @@ plainto_tsquery('simple', test.value) then
+                    if not to_tsvector('english_german', key_value) @@ aux.custom_to_tsquery(test.value) then
                         return false;
                     end if;
                 when 'daterange' then


### PR DESCRIPTION
- Offer "websearch" syntax for FTS queries, like `signal -"segmentation fault"`.  
  This uses the function `websearch_to_tsquery`, which supports the following constructs (see [PostgreSQL documentation](https://www.postgresql.org/docs/11/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES)): 
    - `unquoted text`: text not inside quote marks will be converted to terms separated by & operators, as if processed by plainto_tsquery.
    - `"quoted text"`: text inside quote marks will be converted to terms separated by <-> operators, as if processed by phraseto_tsquery.
    - `OR`: logical or will be converted to the | operator.
    - `-`: the logical not operator, converted to the the ! operator.
- Applies to general FTS queries and to `simplefts` json attribute tests (currently used in the "title" filter).
- For compatibility with older versions of PostgreSQL we dynamically check the availability of the function `websearch_to_tsquery`. Otherwise we fall back to using `plainto_tsquery`.
