### PR TITLE
Generic needs management

### DIFF
--- a/frontend/elm-application.json
+++ b/frontend/elm-application.json
@@ -26,6 +26,7 @@
         "Types.DebugInfo",
         "Types.Id",
         "Types.Navigation",
+        "Types.Needs",
         "Types.Presentation",
         "Types.Range",
         "Types.Route.Filter",

--- a/frontend/src/elm/App.elm
+++ b/frontend/src/elm/App.elm
@@ -15,6 +15,7 @@ import Cmd.Extra
 import Html exposing (Html)
 import Types.DebugInfo exposing (DebugInfo, debugInfo)
 import Types.Navigation as Navigation exposing (Navigation)
+import Types.Needs
 import Types.Presentation as Presentation exposing (Presentation(..))
 import Types.Route as Route exposing (Route)
 import UI
@@ -64,7 +65,7 @@ init route =
     , cache = Cache.initialModel
     , presentation = GenericPresentation Nothing
     , ui = UI.init
-    , debugInfo = { needs = debugInfo Cache.NeedNothing }
+    , debugInfo = { needs = debugInfo Types.Needs.none }
     }
         |> requestNeeds
         |> Cmd.Extra.andThen (updateRoute route >> Cmd.Extra.withNoCmd)
@@ -131,7 +132,8 @@ requestNeeds model =
                 model.cache
     in
     ( { model
-        | debugInfo = { needs = debugInfo currentNeeds }
+        | debugInfo =
+            { needs = debugInfo (Types.Needs.flatten currentNeeds) }
         , cache = cacheModel
       }
     , Cmd.map CacheMsg cacheCmd

--- a/frontend/src/elm/App.elm
+++ b/frontend/src/elm/App.elm
@@ -127,7 +127,7 @@ requestNeeds model =
             UI.needs (uiContext model) model.ui
 
         ( cacheModel, cacheCmd ) =
-            Cache.require
+            Cache.targetNeeds
                 currentNeeds
                 model.cache
     in

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -1,6 +1,6 @@
 module Cache exposing
     ( ApiData, Model, get
-    , Needs(..), needsFromList, require
+    , Need(..), Needs, require
     , updateWithModifiedDocument
     , ApiError, apiErrorToString
     , Msg(..), initialModel, update
@@ -26,7 +26,7 @@ So the consuming modules will have to deal with the possible states a `RemoteDat
 
 # Declaring required data
 
-@docs Needs, needsFromList, require
+@docs Need, Needs, require
 
 
 # Modifying data locally (preliminary)
@@ -64,6 +64,7 @@ import RemoteData exposing (RemoteData(..))
 import Sort.Dict
 import Types exposing (NodeType(..), Window)
 import Types.Id as Id exposing (DocumentId, FolderId, NodeId)
+import Types.Needs as Needs
 import Types.Selection as Selection exposing (SelectMethod(..), Selection)
 import Utils
 
@@ -107,16 +108,19 @@ type alias Model =
 
 {-| A data-consuming module declares its wishes for API data by means of this type.
 -}
-type Needs
-    = NeedNothing
-    | NeedAnd Needs Needs
-    | NeedAndThen Needs Needs
-    | NeedRootFolderIds
+type Need
+    = NeedRootFolderIds
     | NeedSubfolders (List FolderId)
     | NeedGenericNode NodeId
     | NeedDocument DocumentId
     | NeedDocumentsPage Selection Window
     | NeedFolderCounts Selection
+
+
+{-| A collection of these needs.
+-}
+type alias Needs =
+    Needs.Needs Need
 
 
 {-| Describe an `ApiError` as text (aimed for debugging)
@@ -138,18 +142,6 @@ initialModel =
     , documentsPages = Sort.Dict.empty (Utils.sorter orderingSelectionWindow)
     , folderCounts = Sort.Dict.empty (Utils.sorter Selection.orderingSelection)
     }
-
-
-{-| Aggregate a list of needs
--}
-needsFromList : List Needs -> Needs
-needsFromList listOfNeeds =
-    List.foldr
-        (\need accu ->
-            NeedAnd need accu
-        )
-        NeedNothing
-        listOfNeeds
 
 
 {-| Read an entry from a lookup-table of the `Model`.
@@ -177,229 +169,158 @@ type Msg
     | ApiResponseFolderCounts Selection (Api.Response FolderCounts)
 
 
-type Status
-    = NotRequested
-    | Fulfilled
-    | OnGoing
-
-
-statusFromRemoteData : RemoteData e a -> Status
-statusFromRemoteData remoteData =
-    case remoteData of
-        NotAsked ->
-            NotRequested
-
-        Loading ->
-            OnGoing
-
-        Failure _ ->
-            OnGoing
-
-        Success _ ->
-            Fulfilled
-
-
-status : Model -> Needs -> Status
-status model needs =
-    case needs of
-        NeedNothing ->
-            Fulfilled
-
-        NeedAnd needOne needTwo ->
-            let
-                statusOne =
-                    status model needOne
-
-                statusTwo =
-                    status model needTwo
-            in
-            if statusOne == NotRequested || statusTwo == NotRequested then
-                NotRequested
-
-            else if statusOne == OnGoing || statusTwo == OnGoing then
-                OnGoing
-
-            else
-                Fulfilled
-
-        NeedAndThen needOne needTwo ->
-            let
-                statusOne =
-                    status model needOne
-            in
-            if statusOne /= Fulfilled then
-                statusOne
-
-            else
-                status model needTwo
-
-        NeedRootFolderIds ->
-            model.rootFolderIds
-                |> statusFromRemoteData
-
-        NeedSubfolders parentIds ->
-            let
-                listOfRemoteData =
-                    List.map (get model.subfolderIds) parentIds
-            in
-            if List.any RemoteData.isNotAsked listOfRemoteData then
-                NotRequested
-
-            else if List.all RemoteData.isSuccess listOfRemoteData then
-                Fulfilled
-
-            else
-                OnGoing
-
-        NeedGenericNode nodeId ->
-            get model.nodeTypes nodeId
-                |> statusFromRemoteData
-
-        NeedDocument documentId ->
-            get model.documents documentId
-                |> statusFromRemoteData
-
-        NeedDocumentsPage selection window ->
-            get model.documentsPages ( selection, window )
-                |> statusFromRemoteData
-
-        NeedFolderCounts selection ->
-            get model.folderCounts selection
-                |> statusFromRemoteData
-
-
 {-| Check which of the needed data has not yet been requested.
 Submit API requests to get that data and mark the corresponding Model entries as `RemoteData.Loading`.
 -}
 require : Needs -> Model -> ( Model, Cmd Msg )
 require needs model =
-    if status model needs /= NotRequested then
-        ( model, Cmd.none )
+    Needs.requireNeeds
+        (statusOfNeed model)
+        requestNeed
+        needs
+        model
 
-    else
-        case needs of
-            NeedNothing ->
+
+{-| Check the status of an atomic need.
+-}
+statusOfNeed : Model -> Need -> Needs.Status
+statusOfNeed model need =
+    case need of
+        NeedRootFolderIds ->
+            model.rootFolderIds
+                |> Needs.statusFromRemoteData
+
+        NeedSubfolders parentIds ->
+            Needs.statusFromListOfRemoteData
+                (List.map (get model.subfolderIds) parentIds)
+
+        NeedGenericNode nodeId ->
+            get model.nodeTypes nodeId
+                |> Needs.statusFromRemoteData
+
+        NeedDocument documentId ->
+            get model.documents documentId
+                |> Needs.statusFromRemoteData
+
+        NeedDocumentsPage selection window ->
+            get model.documentsPages ( selection, window )
+                |> Needs.statusFromRemoteData
+
+        NeedFolderCounts selection ->
+            get model.folderCounts selection
+                |> Needs.statusFromRemoteData
+
+
+{-| Submit API requests to satisfy an atomic need.
+
+Will be called only for needs that are known not to be in progress or fulfilled yet.
+
+Also mark the corresponding Model entries as `RemoteData.Loading`.
+
+-}
+requestNeed : Need -> Model -> ( Model, Cmd Msg )
+requestNeed need model =
+    case need of
+        NeedRootFolderIds ->
+            ( { model
+                | rootFolderIds = Loading
+              }
+            , Api.sendQueryRequest
+                ApiResponseToplevelFolder
+                Api.Queries.toplevelFolder
+            )
+
+        NeedSubfolders parentIds ->
+            let
+                parentIdsWithUnknownChildren =
+                    List.filter
+                        (\parentId ->
+                            get model.subfolderIds parentId == NotAsked
+                        )
+                        parentIds
+            in
+            if List.isEmpty parentIdsWithUnknownChildren then
                 ( model, Cmd.none )
 
-            NeedAnd needOne needTwo ->
-                let
-                    ( modelOne, cmdOne ) =
-                        require needOne model
-
-                    ( modelTwo, cmdTwo ) =
-                        require needTwo modelOne
-                in
-                ( modelTwo
-                , Cmd.batch [ cmdOne, cmdTwo ]
-                )
-
-            NeedAndThen needOne needTwo ->
-                if status model needOne == Fulfilled then
-                    require needTwo model
-
-                else
-                    require needOne model
-
-            NeedRootFolderIds ->
+            else
                 ( { model
-                    | rootFolderIds = Loading
-                  }
-                , Api.sendQueryRequest
-                    ApiResponseToplevelFolder
-                    Api.Queries.toplevelFolder
-                )
-
-            NeedSubfolders parentIds ->
-                let
-                    parentIdsWithUnknownChildren =
-                        List.filter
-                            (\parentId ->
-                                get model.subfolderIds parentId == NotAsked
+                    | subfolderIds =
+                        List.foldl
+                            (\parentId subfolderIds ->
+                                Sort.Dict.insert parentId Loading subfolderIds
                             )
-                            parentIds
-                in
-                if List.isEmpty parentIdsWithUnknownChildren then
-                    ( model, Cmd.none )
-
-                else
-                    ( { model
-                        | subfolderIds =
-                            List.foldl
-                                (\parentId subfolderIds ->
-                                    Sort.Dict.insert parentId Loading subfolderIds
-                                )
-                                model.subfolderIds
-                                parentIdsWithUnknownChildren
-                      }
-                    , Api.sendQueryRequest
-                        (ApiResponseSubfolder parentIdsWithUnknownChildren)
-                        (Api.Queries.subfolder parentIdsWithUnknownChildren)
-                    )
-
-            NeedGenericNode nodeId ->
-                ( { model
-                    | nodeTypes =
-                        Sort.Dict.insert nodeId Loading model.nodeTypes
+                            model.subfolderIds
+                            parentIdsWithUnknownChildren
                   }
                 , Api.sendQueryRequest
-                    (ApiResponseGenericNode nodeId)
-                    (Api.Queries.genericNode nodeId)
+                    (ApiResponseSubfolder parentIdsWithUnknownChildren)
+                    (Api.Queries.subfolder parentIdsWithUnknownChildren)
                 )
 
-            NeedDocument documentId ->
-                ( { model
-                    | documents =
-                        Sort.Dict.insert documentId Loading model.documents
-                  }
-                , Api.sendQueryRequest
-                    (ApiResponseDocument documentId)
-                    (Api.Queries.documentDetails documentId)
+        NeedGenericNode nodeId ->
+            ( { model
+                | nodeTypes =
+                    Sort.Dict.insert nodeId Loading model.nodeTypes
+              }
+            , Api.sendQueryRequest
+                (ApiResponseGenericNode nodeId)
+                (Api.Queries.genericNode nodeId)
+            )
+
+        NeedDocument documentId ->
+            ( { model
+                | documents =
+                    Sort.Dict.insert documentId Loading model.documents
+              }
+            , Api.sendQueryRequest
+                (ApiResponseDocument documentId)
+                (Api.Queries.documentDetails documentId)
+            )
+
+        NeedDocumentsPage selection window ->
+            ( { model
+                | documentsPages =
+                    Sort.Dict.insert ( selection, window ) Loading model.documentsPages
+              }
+            , Api.sendQueryRequest
+                (ApiResponseDocumentsPage ( selection, window ))
+                (case selection.selectMethod of
+                    SelectByFolderListing ->
+                        Api.Queries.folderDocumentsPage
+                            window
+                            selection.scope
+                            selection.filters
+
+                    SelectByFullTextSearch searchTerm ftsSorting ->
+                        Api.Queries.ftsPage
+                            window
+                            selection.scope
+                            searchTerm
+                            ftsSorting
+                            selection.filters
                 )
+            )
 
-            NeedDocumentsPage selection window ->
-                ( { model
-                    | documentsPages =
-                        Sort.Dict.insert ( selection, window ) Loading model.documentsPages
-                  }
-                , Api.sendQueryRequest
-                    (ApiResponseDocumentsPage ( selection, window ))
-                    (case selection.selectMethod of
-                        SelectByFolderListing ->
-                            Api.Queries.folderDocumentsPage
-                                window
-                                selection.scope
-                                selection.filters
+        NeedFolderCounts selection ->
+            ( { model
+                | folderCounts =
+                    Sort.Dict.insert selection Loading model.folderCounts
+              }
+            , Api.sendQueryRequest
+                (ApiResponseFolderCounts selection)
+                (case selection.selectMethod of
+                    SelectByFolderListing ->
+                        Api.Queries.folderDocumentsFolderCounts
+                            selection.scope
+                            selection.filters
 
-                        SelectByFullTextSearch searchTerm ftsSorting ->
-                            Api.Queries.ftsPage
-                                window
-                                selection.scope
-                                searchTerm
-                                ftsSorting
-                                selection.filters
-                    )
+                    SelectByFullTextSearch searchTerm ftsSorting ->
+                        Api.Queries.ftsFolderCounts
+                            selection.scope
+                            searchTerm
+                            selection.filters
                 )
-
-            NeedFolderCounts selection ->
-                ( { model
-                    | folderCounts =
-                        Sort.Dict.insert selection Loading model.folderCounts
-                  }
-                , Api.sendQueryRequest
-                    (ApiResponseFolderCounts selection)
-                    (case selection.selectMethod of
-                        SelectByFolderListing ->
-                            Api.Queries.folderDocumentsFolderCounts
-                                selection.scope
-                                selection.filters
-
-                        SelectByFullTextSearch searchTerm ftsSorting ->
-                            Api.Queries.ftsFolderCounts
-                                selection.scope
-                                searchTerm
-                                selection.filters
-                    )
-                )
+            )
 
 
 {-| Insert or update a document into the table `Model.documents`.
@@ -488,7 +409,7 @@ update msg model =
                             model1
                                 |> insertAsFolders folders
                                 |> require
-                                    (NeedSubfolders (List.map .id folders))
+                                    (Needs.atomic (NeedSubfolders (List.map .id folders)))
                     in
                     ( model2
                     , cmd

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -1,6 +1,6 @@
 module Cache exposing
     ( ApiData, Model, get
-    , Need(..), Needs, require
+    , Need(..), Needs, targetNeeds
     , updateWithModifiedDocument
     , ApiError, apiErrorToString
     , Msg(..), initialModel, update
@@ -26,7 +26,7 @@ So the consuming modules will have to deal with the possible states a `RemoteDat
 
 # Declaring required data
 
-@docs Need, Needs, require
+@docs Need, Needs, targetNeeds
 
 
 # Modifying data locally (preliminary)
@@ -172,9 +172,9 @@ type Msg
 {-| Check which of the needed data has not yet been requested.
 Submit API requests to get that data and mark the corresponding Model entries as `RemoteData.Loading`.
 -}
-require : Needs -> Model -> ( Model, Cmd Msg )
-require needs model =
-    Needs.requireNeeds
+targetNeeds : Needs -> Model -> ( Model, Cmd Msg )
+targetNeeds needs model =
+    Needs.target
         (statusOfNeed model)
         requestNeed
         needs
@@ -408,7 +408,7 @@ update msg model =
                         ( model2, cmd ) =
                             model1
                                 |> insertAsFolders folders
-                                |> require
+                                |> targetNeeds
                                     (Needs.atomic (NeedSubfolders (List.map .id folders)))
                     in
                     ( model2

--- a/frontend/src/elm/Types/Needs.elm
+++ b/frontend/src/elm/Types/Needs.elm
@@ -1,0 +1,211 @@
+module Types.Needs exposing
+    ( Needs
+    , none, atomic, batch, sequence
+    , Status(..)
+    , statusFromRemoteData, statusFromListOfRemoteData
+    , StatusOfAtomicNeed, RequestAtomicNeed, requireNeeds
+    , flatten
+    )
+
+{-| Generic types and functions to manage a collection of needs.
+
+@docs Needs
+@docs none, atomic, batch, sequence
+@docs Status
+@docs statusFromRemoteData, statusFromListOfRemoteData
+@docs StatusOfAtomicNeed, RequestAtomicNeed, requireNeeds
+@docs flatten
+
+-}
+
+import RemoteData exposing (RemoteData(..))
+
+
+{-| -}
+type Needs n
+    = Atomic n
+    | Batch (List (Needs n))
+    | Sequence (Needs n) (Needs n)
+
+
+{-| -}
+none : Needs n
+none =
+    Batch []
+
+
+{-| -}
+atomic : n -> Needs n
+atomic =
+    Atomic
+
+
+{-| -}
+batch : List (Needs n) -> Needs n
+batch =
+    Batch
+
+
+{-| -}
+sequence : Needs n -> Needs n -> Needs n
+sequence =
+    Sequence
+
+
+{-| -}
+flatten : Needs n -> Needs n
+flatten needs =
+    let
+        asList : Needs n -> List (Needs n)
+        asList needs1 =
+            case needs1 of
+                Atomic _ ->
+                    [ needs1 ]
+
+                Batch listOfNeeds ->
+                    listOfNeeds
+
+                Sequence _ _ ->
+                    [ needs1 ]
+    in
+    case needs of
+        Atomic _ ->
+            needs
+
+        Batch listOfNeeds ->
+            listOfNeeds
+                |> List.concatMap (flatten >> asList)
+                |> Batch
+
+        Sequence needsFirst needsSecond ->
+            case flatten needsFirst of
+                Batch [] ->
+                    flatten needsSecond
+
+                needsFirstFlat ->
+                    case flatten needsSecond of
+                        Batch [] ->
+                            needsFirstFlat
+
+                        needsSecondFlat ->
+                            Sequence
+                                needsFirstFlat
+                                needsSecondFlat
+
+
+{-| -}
+type Status
+    = NotRequested
+    | Fulfilled
+    | OnGoing
+
+
+statusPlus : Status -> Status -> Status
+statusPlus statusOne statusTwo =
+    if statusOne == NotRequested || statusTwo == NotRequested then
+        NotRequested
+
+    else if statusOne == OnGoing || statusTwo == OnGoing then
+        OnGoing
+
+    else
+        Fulfilled
+
+
+{-| -}
+statusFromRemoteData : RemoteData e a -> Status
+statusFromRemoteData remoteData =
+    case remoteData of
+        NotAsked ->
+            NotRequested
+
+        Loading ->
+            OnGoing
+
+        Failure _ ->
+            OnGoing
+
+        Success _ ->
+            Fulfilled
+
+
+{-| -}
+statusFromListOfRemoteData : List (RemoteData e a) -> Status
+statusFromListOfRemoteData listOfRemoteData =
+    if List.any RemoteData.isNotAsked listOfRemoteData then
+        NotRequested
+
+    else if List.all RemoteData.isSuccess listOfRemoteData then
+        Fulfilled
+
+    else
+        OnGoing
+
+
+statusOfNeeds : (n -> Status) -> Needs n -> Status
+statusOfNeeds statusOfAtomicNeed needs =
+    case needs of
+        Atomic need ->
+            statusOfAtomicNeed need
+
+        Batch listOfNeeds ->
+            List.foldl
+                (\subNeeds statucAcc ->
+                    statusPlus
+                        (statusOfNeeds statusOfAtomicNeed subNeeds)
+                        statucAcc
+                )
+                Fulfilled
+                listOfNeeds
+
+        Sequence needsFirst needsSecond ->
+            let
+                statusFirst =
+                    statusOfNeeds statusOfAtomicNeed needsFirst
+            in
+            if statusFirst /= Fulfilled then
+                statusFirst
+
+            else
+                statusOfNeeds statusOfAtomicNeed needsSecond
+
+
+{-| -}
+type alias StatusOfAtomicNeed n =
+    n -> Status
+
+
+{-| -}
+type alias RequestAtomicNeed n a msg =
+    n -> a -> ( a, Cmd msg )
+
+
+{-| -}
+requireNeeds : StatusOfAtomicNeed n -> RequestAtomicNeed n a msg -> Needs n -> a -> ( a, Cmd msg )
+requireNeeds statusOfAtomicNeed requestAtomicNeed needs acc =
+    case needs of
+        Atomic need ->
+            if statusOfAtomicNeed need == NotRequested then
+                requestAtomicNeed need acc
+
+            else
+                ( acc, Cmd.none )
+
+        Batch listOfNeeds ->
+            List.foldl
+                (\needs1 ( acc1, cmd1 ) ->
+                    let
+                        ( acc2, cmd2 ) =
+                            requireNeeds statusOfAtomicNeed requestAtomicNeed needs1 acc1
+                    in
+                    ( acc2, Cmd.batch [ cmd1, cmd2 ] )
+                )
+                ( acc, Cmd.none )
+                listOfNeeds
+
+        Sequence needsFirst needsSecond ->
+            if statusOfNeeds statusOfAtomicNeed needsFirst == Fulfilled then
+                requireNeeds statusOfAtomicNeed requestAtomicNeed needsSecond acc
+
+            else
+                requireNeeds statusOfAtomicNeed requestAtomicNeed needsFirst acc

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -16,6 +16,7 @@ import Html exposing (Html)
 import Html.Attributes
 import Html.Events
 import Types.Navigation as Navigation exposing (Navigation)
+import Types.Needs
 import Types.Presentation exposing (Presentation(..))
 import Types.Route as Route exposing (Route)
 import UI.Article
@@ -82,8 +83,8 @@ init =
 -}
 needs : Context -> Model -> Cache.Needs
 needs context model =
-    Cache.needsFromList
-        [ Cache.NeedRootFolderIds
+    Types.Needs.batch
+        [ Types.Needs.atomic Cache.NeedRootFolderIds
         , UI.Tree.needs
             { cache = context.cache
             , presentation = context.presentation

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -36,6 +36,7 @@ import RemoteData exposing (RemoteData)
 import Sort.Dict
 import Types exposing (FolderDisplay(..))
 import Types.Id exposing (FolderId)
+import Types.Needs
 import Types.Presentation as Presentation exposing (Presentation(..))
 import UI.Icons
 import Utils
@@ -79,6 +80,7 @@ needs context model =
     getPresentationFolderId context
         |> Cache.Derive.getPathAsFarAsCached context.cache
         |> Cache.NeedSubfolders
+        |> Types.Needs.atomic
 
 
 {-| -}

--- a/frontend/tests/Tests/Types/Needs.elm
+++ b/frontend/tests/Tests/Types/Needs.elm
@@ -1,0 +1,122 @@
+module Tests.Types.Needs exposing (suite)
+
+import Expect
+import Fuzz exposing (Fuzzer)
+import List.Extra
+import Test exposing (..)
+import TestUtils exposing (..)
+import Types.Needs as Needs
+
+
+type alias TheNeed =
+    String
+
+
+type alias TheNeeds =
+    Needs.Needs TheNeed
+
+
+needs0 : TheNeeds
+needs0 =
+    Needs.batch
+        [ Needs.none
+        , Needs.sequence Needs.none Needs.none
+        , Needs.none
+        , Needs.batch [ Needs.none, Needs.none, Needs.none ]
+        , Needs.none
+        ]
+
+
+needs1 : TheNeeds
+needs1 =
+    Needs.batch
+        [ Needs.none
+        , Needs.sequence (Needs.atomic "1S1") (Needs.atomic "1S2")
+        , Needs.none
+        , Needs.atomic "2"
+        , Needs.batch [ Needs.atomic "3B1", Needs.atomic "3B2" ]
+        , Needs.none
+        , Needs.atomic "4"
+        , Needs.sequence (Needs.atomic "5S1") (Needs.atomic "5S2")
+        , Needs.none
+        , Needs.atomic "6"
+        , Needs.batch [ Needs.atomic "7B1", Needs.atomic "7B2" ]
+        , Needs.none
+        , Needs.sequence (Needs.atomic "8") needs0
+        , Needs.sequence needs0 (Needs.atomic "9")
+        , Needs.none
+        ]
+
+
+needs1FlatList : List TheNeeds
+needs1FlatList =
+    [ Needs.sequence (Needs.atomic "1S1") (Needs.atomic "1S2")
+    , Needs.atomic "2"
+    , Needs.atomic "3B1"
+    , Needs.atomic "3B2"
+    , Needs.atomic "4"
+    , Needs.sequence (Needs.atomic "5S1") (Needs.atomic "5S2")
+    , Needs.atomic "6"
+    , Needs.atomic "7B1"
+    , Needs.atomic "7B2"
+    , Needs.atomic "8"
+    , Needs.atomic "9"
+    ]
+
+
+needs2 : TheNeeds
+needs2 =
+    Needs.batch
+        [ Needs.none
+        , needs1
+        , Needs.none
+        , Needs.atomic "---"
+        , Needs.none
+        , needs1
+        , Needs.none
+        ]
+
+
+needs2FlatList : List TheNeeds
+needs2FlatList =
+    needs1FlatList ++ (Needs.atomic "---" :: needs1FlatList)
+
+
+needs3 : TheNeeds
+needs3 =
+    Needs.sequence
+        needs1
+        (Needs.batch [ Needs.atomic "---", needs1 ])
+
+
+needs3Flat : TheNeeds
+needs3Flat =
+    Needs.sequence
+        (Needs.batch needs1FlatList)
+        (Needs.batch (Needs.atomic "---" :: needs1FlatList))
+
+
+suite : Test
+suite =
+    describe "Types.Needs"
+        [ describe "flatten"
+            [ describe "fixed test cases"
+                [ test "needs0" <|
+                    \() ->
+                        Needs.flatten needs0
+                            |> Expect.equal Needs.none
+                , test "needs1" <|
+                    \() ->
+                        Needs.flatten needs1
+                            |> Expect.equal (Needs.batch needs1FlatList)
+                , test "needs2" <|
+                    \() ->
+                        Needs.flatten needs2
+                            |> Expect.equal (Needs.batch needs2FlatList)
+                , test "needs3" <|
+                    \() ->
+                        Needs.flatten needs3
+                            |> Expect.equal needs3Flat
+                ]
+            ]
+        ]


### PR DESCRIPTION
We split off generic code for managing collections of needs from module `Cache` into module `Types.Needs`.

The remaining code in `Cache` now focuses on the management of atomic needs.
