### PR TITLE
Single Title Filter

### DIFF
--- a/frontend/src/elm/Types/Route.elm
+++ b/frontend/src/elm/Types/Route.elm
@@ -26,7 +26,7 @@ Parsing URLs and stringifying routes are defined in [`Types.Route.Url`](Types-Ro
 
 import Types.Id exposing (DocumentId, FolderId, NodeId)
 import Types.Range exposing (Range)
-import Types.SearchTerm exposing (SearchTerm, SetOfSearchTerms)
+import Types.SearchTerm exposing (SearchTerm)
 import Types.Selection exposing (FtsSorting(..))
 
 
@@ -61,7 +61,7 @@ type alias RouteParameters =
     { ftsTerm : Maybe SearchTerm
     , ftsSorting : FtsSorting
     , filterByYear : Maybe (Range Int)
-    , filterByTitle : SetOfSearchTerms
+    , filterByTitle : Maybe SearchTerm
     , offset : Int
     , limit : Int
     }
@@ -89,7 +89,7 @@ emptyParameters =
     { ftsTerm = Nothing
     , ftsSorting = defaultFtsSorting
     , filterByYear = Nothing
-    , filterByTitle = Types.SearchTerm.emptySet
+    , filterByTitle = Nothing
     , offset = 0
     , limit = defaultLimit
     }

--- a/frontend/src/elm/Types/Route/Filter.elm
+++ b/frontend/src/elm/Types/Route/Filter.elm
@@ -10,8 +10,8 @@ module Types.Route.Filter exposing
 
 -}
 
+import Maybe.Extra
 import Types.Route exposing (Route)
-import Types.SearchTerm
 import Types.Selection as Selection exposing (Filter(..), SetOfFilters)
 import Utils
 
@@ -19,13 +19,10 @@ import Utils
 {-| -}
 fromRoute : Route -> SetOfFilters
 fromRoute route =
-    route.parameters.filterByTitle
-        |> Types.SearchTerm.setToList
-        |> List.map FilterTitleFts
-        |> Utils.prependMaybe
-            (route.parameters.filterByYear
-                |> Maybe.map FilterYearWithin
-            )
+    [ route.parameters.filterByYear |> Maybe.map FilterYearWithin
+    , route.parameters.filterByTitle |> Maybe.map FilterTitleFts
+    ]
+        |> Maybe.Extra.values
         |> Selection.filtersFromList
 
 
@@ -50,7 +47,7 @@ alterRoute filters route =
 
         filterByTitle =
             listOfFilters
-                |> List.filterMap
+                |> Utils.findMap
                     (\filter ->
                         case filter of
                             FilterTitleFts titleSearchTerm ->
@@ -59,7 +56,6 @@ alterRoute filters route =
                             _ ->
                                 Nothing
                     )
-                |> Types.SearchTerm.setFromList
 
         parameters =
             route.parameters

--- a/frontend/src/elm/Types/Route/Url.elm
+++ b/frontend/src/elm/Types/Route/Url.elm
@@ -65,11 +65,9 @@ parserParameters =
                     )
                 )
         )
-        (QueryParser.custom "filter-by-title"
-            (List.map Types.SearchTerm.fromString
-                >> Maybe.Extra.values
-                >> Types.SearchTerm.setFromList
-            )
+        (QueryParser.string "filter-by-title"
+            |> QueryParser.map
+                (Maybe.andThen Types.SearchTerm.fromString)
         )
         (QueryParser.int "offset"
             |> queryParserWithDefault 0
@@ -139,24 +137,20 @@ toString route =
                             ++ Maybe.Extra.unwrap "" String.fromInt maybeYear2
                 )
                 route.parameters.filterByYear
+            , route.parameters.filterByTitle
+                |> Maybe.map
+                    (Types.SearchTerm.toString
+                        >> Builder.string "filter-by-title"
+                    )
+            , buildParameterIfNotDefault
+                (Builder.int "offset")
+                0
+                route.parameters.offset
+            , buildParameterIfNotDefault
+                (Builder.int "limit")
+                Route.defaultLimit
+                route.parameters.limit
             ]
-            ++ (route.parameters.filterByTitle
-                    |> Types.SearchTerm.setToList
-                    |> List.map
-                        (Types.SearchTerm.toString
-                            >> Builder.string "filter-by-title"
-                        )
-               )
-            ++ Maybe.Extra.values
-                [ buildParameterIfNotDefault
-                    (Builder.int "offset")
-                    0
-                    route.parameters.offset
-                , buildParameterIfNotDefault
-                    (Builder.int "limit")
-                    Route.defaultLimit
-                    route.parameters.limit
-                ]
         )
 
 

--- a/frontend/src/elm/Types/SearchTerm.elm
+++ b/frontend/src/elm/Types/SearchTerm.elm
@@ -4,11 +4,6 @@ module Types.SearchTerm exposing
     , fromStringWithDefault
     , toString
     , ordering
-    , SetOfSearchTerms
-    , emptySet
-    , setIsEmpty
-    , setFromList
-    , setToList
     )
 
 {-|
@@ -22,18 +17,8 @@ module Types.SearchTerm exposing
 @docs toString
 @docs ordering
 
-
-# Set of search terms
-
-@docs SetOfSearchTerms
-@docs emptySet
-@docs setIsEmpty
-@docs setFromList
-@docs setToList
-
 -}
 
-import List.Unique
 import Ordering exposing (Ordering)
 import String.Extra
 
@@ -81,34 +66,3 @@ toString (SearchTerm string) =
 ordering : Ordering SearchTerm
 ordering =
     Ordering.byField toString
-
-
-{-| A set of unique search terms
--}
-type SetOfSearchTerms
-    = SetOfSearchTerms (List.Unique.UniqueList SearchTerm)
-
-
-{-| -}
-emptySet : SetOfSearchTerms
-emptySet =
-    SetOfSearchTerms List.Unique.empty
-
-
-{-| -}
-setIsEmpty : SetOfSearchTerms -> Bool
-setIsEmpty (SetOfSearchTerms set) =
-    List.Unique.isEmpty set
-
-
-{-| -}
-setFromList : List SearchTerm -> SetOfSearchTerms
-setFromList list =
-    SetOfSearchTerms <|
-        List.Unique.fromList list
-
-
-{-| -}
-setToList : SetOfSearchTerms -> List SearchTerm
-setToList (SetOfSearchTerms set) =
-    List.Unique.toList set

--- a/frontend/src/elm/Types/Selection.elm
+++ b/frontend/src/elm/Types/Selection.elm
@@ -80,7 +80,7 @@ type FtsSorting
     | FtsByDate
 
 
-{-| A `SetOfFilters` may contain one single `FilterYearWithin` and zero or more `FilterTitleFts` as long as the search terms a unqiue.
+{-| A `SetOfFilters` may contain one single `FilterYearWithin` and one single `FilterTitleFts`.
 -}
 type SetOfFilters
     = SetOfFilters (Sort.Dict.Dict FilterHandle Filter)
@@ -140,8 +140,7 @@ filterHandle filter =
                 "YearWithin"
 
             FilterTitleFts searchTerm ->
-                "TitleFts-"
-                    ++ SearchTerm.toString searchTerm
+                "TitleFts"
 
 
 {-| Used for newly created filter editors.

--- a/frontend/src/elm/UI/Controls/Filter.elm
+++ b/frontend/src/elm/UI/Controls/Filter.elm
@@ -130,7 +130,7 @@ viewEditControls focusId controls =
                     , Html.Attributes.type_ "number"
                     , Html.Attributes.min "1900"
                     , Html.Attributes.max "2100"
-                    , Html.Attributes.placeholder "from"
+                    , Html.Attributes.placeholder "From Year"
                     , Html.Attributes.value
                         (Maybe.Extra.unwrap "" String.fromInt from)
                     , Utils.onChange
@@ -143,7 +143,7 @@ viewEditControls focusId controls =
                     [ Html.Attributes.type_ "number"
                     , Html.Attributes.min "1900"
                     , Html.Attributes.max "2100"
-                    , Html.Attributes.placeholder "to"
+                    , Html.Attributes.placeholder "To Year"
                     , Html.Attributes.value
                         (Maybe.Extra.unwrap "" String.fromInt to)
                     , Utils.onChange
@@ -160,7 +160,7 @@ viewEditControls focusId controls =
                 [ Html.input
                     [ Html.Attributes.id focusId
                     , Html.Attributes.type_ "text"
-                    , Html.Attributes.placeholder "Title full text filter"
+                    , Html.Attributes.placeholder "Title Filter"
                     , Html.Attributes.value searchTerm
                     , Utils.onChange ControlsTitleFts
                     ]

--- a/frontend/tests/Tests/Types/Route.elm
+++ b/frontend/tests/Tests/Types/Route.elm
@@ -31,8 +31,8 @@ fuzzerRoute =
                     |> Fuzz.maybe
                 )
             |> Fuzz.andMap
-                (TestUtils.shortList 4 fuzzerSearchTerm
-                    |> Fuzz.map Types.SearchTerm.setFromList
+                (fuzzerSearchTerm
+                    |> Fuzz.maybe
                 )
             |> Fuzz.andMap
                 fuzzerOffset


### PR DESCRIPTION
We've discussed the UX of filtering by title.

Up to now the user can specify multiple title filters, each with multiple search terms.
This may be confusing and too much of a good thing.

So we restrict the UI and the URL parameters to have at most one title filter.
