### PR TITLE
Fix FTS sorting in SQL function

### DIFF
--- a/backend/bin/start
+++ b/backend/bin/start
@@ -31,5 +31,6 @@ node_modules/.bin/postgraphile \
     --legacy-relations=omit \
     --no-ignore-rbac \
     --enhance-graphiql \
+    --allow-explain
     
 #     --dynamic-json \

--- a/backend/src/sql/api-facets.sql
+++ b/backend/src/sql/api-facets.sql
@@ -27,6 +27,12 @@ create or replace function api.all_documents_docset
 $$ language plpgsql stable parallel safe;
 
 
+comment on function api.all_documents_docset (folder_id int4, type text, name text, attribute_tests api.attribute_test[]) is
+    'Perform a documents listing on a folder to provide a list of document ids, '
+    'intended to be consumed by a facet-counting function.'
+;
+
+
 create or replace function aux.fts_documents_tsquery_docset
     ( folder_id int4
     , fts_query tsquery


### PR DESCRIPTION
Sorting FTS results by date or by rank seems buggy.
Sometimes the results don't get sorted at all.

The SQL function `aux.fts_documents_limited` is responsible for this sorting.
The functions uses two nested select statements.
Sorting used to be performed in the inner statement. We relied in the experience that the sorting is preserved in the operations of the outer statement. This may not be true in all cases anymore.

As a hot-fix we add an `order` clause to the outer query too.

TODO: Reevaluate performance behaviour of that function. It seems to be somewhat degraded.