### PR TITLE
Avoid repeated queries on sorting-independent docsets

### DIFF
--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -145,7 +145,7 @@ init =
     , nodeTypes = Sort.Dict.empty (Utils.sorter Id.ordering)
     , documents = Sort.Dict.empty (Utils.sorter Id.ordering)
     , documentsPages = Sort.Dict.empty (Utils.sorter orderingSelectionWindow)
-    , folderCounts = Sort.Dict.empty (Utils.sorter Selection.orderingSelection)
+    , folderCounts = Sort.Dict.empty (Utils.sorter Selection.orderingSelectionModuloSorting)
     , facetsValues = Sort.Dict.empty (Utils.sorter orderingSelectionFacet)
     }
 
@@ -584,6 +584,6 @@ orderingSelectionWindow =
 -}
 orderingSelectionFacet : Ordering ( Selection, String )
 orderingSelectionFacet =
-    Ordering.byFieldWith Selection.orderingSelection Tuple.first
+    Ordering.byFieldWith Selection.orderingSelectionModuloSorting Tuple.first
         |> Ordering.breakTiesWith
             (Ordering.byFieldWith Ordering.natural Tuple.second)

--- a/frontend/tests/TestUtils.elm
+++ b/frontend/tests/TestUtils.elm
@@ -9,6 +9,7 @@ module TestUtils exposing
     , testOrderingProperties
     , testOrderingReflexivity
     , testOrderingTransitivity
+    , testPreorderingProperties
     , testString
     )
 
@@ -98,7 +99,7 @@ shortList maxLength fuzzerElement =
             ]
 
 
-{-| Test the reuqired properties of a strict total ordering on a given type:
+{-| Test the required properties of a strict total ordering on a given type:
 reflexivity, antisymmetry and transitivity
 -}
 testOrderingProperties : String -> Fuzzer a -> (a -> a -> Order) -> Test
@@ -106,6 +107,17 @@ testOrderingProperties name fuzzer ordering =
     Test.describe name
         [ testOrderingReflexivity "reflexivity" fuzzer ordering
         , testOrderingAntisymmetry "antisymmetry" fuzzer ordering
+        , testOrderingTransitivity "transitivity" fuzzer ordering
+        ]
+
+
+{-| Test the required properties of a total preordering on a given type:
+reflexivity and transitivity
+-}
+testPreorderingProperties : String -> Fuzzer a -> (a -> a -> Order) -> Test
+testPreorderingProperties name fuzzer ordering =
+    Test.describe name
+        [ testOrderingReflexivity "reflexivity" fuzzer ordering
         , testOrderingTransitivity "transitivity" fuzzer ordering
         ]
 


### PR DESCRIPTION
FTS queries can be sorted either by rank or by date.
The sorting should only affect the document listing.
Sorting is irrelevant for queries on docsets like folder counts or facets.
These queries shouldn't be repeated when the sorting is changed.

For this we make the relevant cache tables ignore the FtsSorting parameter.