### PR TITLE
Annotate API queries with GraphQL operation names

### DIFF
--- a/frontend/elm.json
+++ b/frontend/elm.json
@@ -9,7 +9,7 @@
         "direct": {
             "Chadtech/unique-list": "2.1.1",
             "Janiczek/cmd-extra": "1.1.0",
-            "dillonkearns/elm-graphql": "4.3.1",
+            "dillonkearns/elm-graphql": "5.0.0",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -237,6 +237,7 @@ requestNeed need cache =
                 | rootFolderIds = Loading
               }
             , Api.sendQueryRequest
+                (Api.withOperationName "NeedRootFolderIds")
                 ApiResponseToplevelFolder
                 Api.Queries.toplevelFolder
             )
@@ -264,6 +265,7 @@ requestNeed need cache =
                             parentIdsWithUnknownChildren
                   }
                 , Api.sendQueryRequest
+                    (Api.withOperationName "NeedSubfolders")
                     (ApiResponseSubfolder parentIdsWithUnknownChildren)
                     (Api.Queries.subfolder parentIdsWithUnknownChildren)
                 )
@@ -274,6 +276,7 @@ requestNeed need cache =
                     Sort.Dict.insert nodeId Loading cache.nodeTypes
               }
             , Api.sendQueryRequest
+                (Api.withOperationName "NeedGenericNode")
                 (ApiResponseGenericNode nodeId)
                 (Api.Queries.genericNode nodeId)
             )
@@ -284,6 +287,7 @@ requestNeed need cache =
                     Sort.Dict.insert documentId Loading cache.documents
               }
             , Api.sendQueryRequest
+                (Api.withOperationName "NeedDocument")
                 (ApiResponseDocument documentId)
                 (Api.Queries.documentDetails documentId)
             )
@@ -294,6 +298,7 @@ requestNeed need cache =
                     Sort.Dict.insert ( selection, window ) Loading cache.documentsPages
               }
             , Api.sendQueryRequest
+                (Api.withOperationName "NeedDocumentsPage")
                 (ApiResponseDocumentsPage ( selection, window ))
                 (Api.Queries.selectionDocumentsPage window selection)
             )
@@ -304,6 +309,7 @@ requestNeed need cache =
                     Sort.Dict.insert selection Loading cache.folderCounts
               }
             , Api.sendQueryRequest
+                (Api.withOperationName "NeedFolderCounts")
                 (ApiResponseFolderCounts selection)
                 (Api.Queries.selectionFolderCounts selection)
             )
@@ -314,6 +320,7 @@ requestNeed need cache =
                     Sort.Dict.insert ( selection, key ) Loading cache.facetsValues
               }
             , Api.sendQueryRequest
+                (Api.withOperationName "NeedFacet")
                 (ApiResponseFacet ( selection, key ))
                 (Api.Queries.selectionFacetByKey selection key Config.facetValuesToQuery)
             )

--- a/frontend/src/elm/Config.elm
+++ b/frontend/src/elm/Config.elm
@@ -1,11 +1,13 @@
 module Config exposing
-    ( apiUrl, pageSize
+    ( apiUrl, graphqlOperationNamePrefix
+    , pageSize
     , facetValuesToQuery, standardFacetKeys
     )
 
 {-| Configurable values
 
-@docs apiUrl, pageSize
+@docs apiUrl, graphqlOperationNamePrefix
+@docs pageSize
 @docs facetValuesToQuery, standardFacetKeys
 
 -}
@@ -16,6 +18,16 @@ module Config exposing
 apiUrl : String
 apiUrl =
     "/graphql"
+
+
+{-| A common prefix to use for all GraphQL operation names used by the app.
+
+For operation names see: <https://graphql.org/learn/queries/#operation-name>
+
+-}
+graphqlOperationNamePrefix : String
+graphqlOperationNamePrefix =
+    "mediatumView_"
 
 
 {-| Number of results per page used for pagination.

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -121,6 +121,7 @@ update context msg model =
         SubmitMutation documentId ->
             ( { model | mutationState = Pending }
             , Api.sendMutationRequest
+                (Api.withOperationName "ModifyDocumentAttribute")
                 (ApiMutationResponse documentId model.editAttributeKey)
                 (Api.Mutations.updateDocumentAttribute
                     documentId


### PR DESCRIPTION
Operation names are shown in the logs of postgraphile,
useful to quickly see the origin and the type of the query.

Currently we use names in the form:
mediatumView_NeedDocumentsPage

cf. https://graphql.org/learn/queries/#operation-name