### PR TITLE
Required GraphQL arguments

### DIFF
--- a/backend/bin/start
+++ b/backend/bin/start
@@ -24,7 +24,6 @@ node_modules/.bin/postgraphile \
     --default-role $MEDIATUM_DATABASE_USER \
     --schema api,debug \
     --cors  \
-    --export-schema-json export/schema-export.json \
     --export-schema-graphql export/schema-export.graphql \
     --watch \
     --no-setof-functions-contain-nulls \

--- a/backend/src/sql/api-document.sql
+++ b/backend/src/sql/api-document.sql
@@ -182,7 +182,7 @@ create or replace function api.document_values_by_mask (document api.document, m
     from entity.document_mask_value_list as v
     where v.document_id = document_values_by_mask.document.id
       and v.mask_name = document_values_by_mask.mask_name
-$$ language sql stable parallel safe;
+$$ language sql strict stable parallel safe;
 
 comment on function api.document_values_by_mask (document api.document, mask_name text) is
     'Gets the meta field values of this document as a JSON value, selected by a named mask.';

--- a/backend/src/sql/api-document.sql
+++ b/backend/src/sql/api-document.sql
@@ -78,7 +78,7 @@ create or replace function api.all_documents_page
                     ( folder_id
                     , nullif(type, 'use null instead of this surrogate dummy')
                     , nullif(name, 'use null instead of this surrogate dummy')
-                    , attribute_tests
+                    , nullif(attribute_tests, '{}')
                     , "limit", "offset"
                     )
             )

--- a/backend/src/sql/api-document.sql
+++ b/backend/src/sql/api-document.sql
@@ -43,7 +43,6 @@ create or replace function aux.all_documents_paginated
         )
     as $$
         begin 
-            raise WARNING 'aux.all_documents_paginated limit = %', "limit";
             return query
             select f
                 , 0.0::float4

--- a/backend/src/sql/api-facets.sql
+++ b/backend/src/sql/api-facets.sql
@@ -20,7 +20,7 @@ create or replace function api.all_documents_docset
         where folder_id = node_lineage.ancestor
         and (all_documents_docset.type = 'use null instead of this surrogate dummy' or document.type = all_documents_docset.type)
         and (all_documents_docset.name = 'use null instead of this surrogate dummy' or document.name = all_documents_docset.name)
-        and (attribute_tests is null or aux.jsonb_test_list (document.attrs, attribute_tests))
+        and (attribute_tests = '{}' or aux.jsonb_test_list (document.attrs, attribute_tests))
         ;
         return res;
     end;
@@ -87,7 +87,7 @@ create or replace function api.fts_documents_docset
         return aux.fts_documents_tsquery_docset
           ( folder_id
           , aux.custom_to_tsquery (text)
-          , attribute_tests
+          , nullif(attribute_tests, '{}')
           );
     end;
 $$ language plpgsql strict stable parallel safe;

--- a/backend/src/sql/api-facets.sql
+++ b/backend/src/sql/api-facets.sql
@@ -210,7 +210,7 @@ create or replace function api.docset_facet_by_key
         group by aux.normalize_facet_value(document.attrs ->> key)
         order by count(aux.normalize_facet_value(document.attrs ->> key)) desc, aux.normalize_facet_value(document.attrs ->> key)
         ;
-$$ language sql stable parallel safe rows 50;
+$$ language sql strict stable parallel safe rows 50;
 
 comment on function api.docset_facet_by_key
     ( docset api.docset
@@ -238,7 +238,7 @@ create or replace function api.docset_facet_by_mask
         group by aux.normalize_facet_value(v.value)
         order by count(aux.normalize_facet_value(v.value)) desc, aux.normalize_facet_value(v.value)
         ;
-$$ language sql stable parallel safe rows 50;
+$$ language sql strict stable parallel safe rows 50;
 
 comment on function api.docset_facet_by_mask
     ( docset api.docset
@@ -253,10 +253,10 @@ comment on function api.docset_facet_by_mask
 
 create or replace function api.all_documents_facet_by_key
     ( folder_id int4
+    , key text
     , type text
     , name text
     , attribute_tests api.attribute_test[]
-    , key text
     )
     returns setof api.facet_value as $$
         select
@@ -275,26 +275,65 @@ $$ language sql stable rows 10000;
 
 comment on function api.all_documents_facet_by_key
     ( folder_id int4
+    , key text
     , type text
     , name text
     , attribute_tests api.attribute_test[]
-    , key text
     ) is
     'Gather the most frequent values of a facet within all documents of a folder. '
     'The facet in question is specified by a JSON attribute key. '
     'Documents without this key indicate the value as the empty string. '
-    'Note: When dealing with large sets of documents, this function is faster '
-    'than composing the functions "all_documents_docset" and "docset_facet_by_key".'
+    'Note: When dealing with large sets of documents, this function may be faster '
+    'than composing the functions "all_documents_docset" and "docset_facet_by_key". '
+    'On the other hand, with smaller sets of documents, it may be slower.'
+;
+
+
+/* Alternatively we may mark the function as strict in order to mark the required arguments.
+   Performance seems equivalent here. But see also notes on function api.all_documents_facet_by_mask_strict.
+*/
+create or replace function api.all_documents_facet_by_key_strict
+    ( folder_id int4
+    , key text
+    , type text default 'use null instead of this surrogate dummy'
+    , name text default 'use null instead of this surrogate dummy'
+    , attribute_tests api.attribute_test[] default '{}'
+    )
+    returns setof api.facet_value as $$
+        select
+            aux.normalize_facet_value(document.attrs ->> key),
+            count (aux.normalize_facet_value(document.attrs ->> key))::integer
+        from entity.document
+        join aux.node_lineage on document.id = node_lineage.descendant
+        where folder_id = node_lineage.ancestor
+        and (all_documents_facet_by_key_strict.type = 'use null instead of this surrogate dummy' or document.type = all_documents_facet_by_key_strict.type)
+        and (all_documents_facet_by_key_strict.name = 'use null instead of this surrogate dummy' or document.name = all_documents_facet_by_key_strict.name)
+        and (attribute_tests = '{}' or aux.jsonb_test_list (document.attrs, attribute_tests))
+        group by aux.normalize_facet_value(document.attrs ->> key)
+        order by count(aux.normalize_facet_value(document.attrs ->> key)) desc, aux.normalize_facet_value(document.attrs ->> key)
+        ;
+$$ language sql strict stable rows 10000;
+
+comment on function api.all_documents_facet_by_key_strict
+    ( folder_id int4
+    , key text
+    , type text
+    , name text
+    , attribute_tests api.attribute_test[]
+    ) is
+    '@deprecated '
+    'Experimental version of function all_documents_facet_by_key, '
+    'having the appropriate parameters marked as required. '
 ;
 
 
 create or replace function api.all_documents_facet_by_mask
     ( folder_id int4
+    , mask_name text
+    , maskitem_name text
     , type text
     , name text
     , attribute_tests api.attribute_test[]
-    , mask_name text
-    , maskitem_name text
     )
     returns setof api.facet_value as $$
         select
@@ -315,15 +354,59 @@ $$ language sql stable rows 10000;
 
 comment on function api.all_documents_facet_by_mask
     ( folder_id int4
+    , mask_name text
+    , maskitem_name text
     , type text
     , name text
     , attribute_tests api.attribute_test[]
-    , mask_name text
-    , maskitem_name text
     ) is
     'Gather the most frequent values of a facet within all documents of a folder. '
     'The facet in question is specified by maskName and maskitemName. '
     'Documents without the corresponding key indicate the value as the empty string. '
-    'Note: When dealing with large sets of documents, this function is faster '
-    'than composing the functions "all_documents_docset" and "docset_facet_by_mask".'
+    'Note: When dealing with large sets of documents, this function may be faster '
+    'than composing the functions "all_documents_docset" and "docset_facet_by_mask". '
+    'On the other hand, with smaller sets of documents, it may be slower.'
 ;
+
+/* We would like to mark the function as strict in order to mark the required arguments.
+   Unfortunately, this results in heavily degraded performance.
+*/
+create or replace function api.all_documents_facet_by_mask_strict
+    ( folder_id int4
+    , mask_name text
+    , maskitem_name text
+    , type text default 'use null instead of this surrogate dummy'
+    , name text default 'use null instead of this surrogate dummy'
+    , attribute_tests api.attribute_test[] default '{}'
+    )
+    returns setof api.facet_value as $$
+        select
+            aux.normalize_facet_value(v.value),
+            count(aux.normalize_facet_value(v.value))::integer
+        from entity.document_mask_fields as v
+        join aux.node_lineage on v.document_id = node_lineage.descendant
+        where folder_id = node_lineage.ancestor
+        and (all_documents_facet_by_mask_strict.type = 'use null instead of this surrogate dummy' or v.document_type = all_documents_facet_by_mask_strict.type)
+        and (all_documents_facet_by_mask_strict.name = 'use null instead of this surrogate dummy' or v.document_name = all_documents_facet_by_mask_strict.name)
+        and (attribute_tests = '{}' or aux.jsonb_test_list (v.document_attrs, attribute_tests))
+        and v.mask_name = all_documents_facet_by_mask_strict.mask_name
+        and v.maskitem_name = all_documents_facet_by_mask_strict.maskitem_name
+        group by aux.normalize_facet_value(v.value)
+        order by count(aux.normalize_facet_value(v.value)) desc, aux.normalize_facet_value(v.value)
+        ;
+$$ language sql strict stable rows 10000;
+
+comment on function api.all_documents_facet_by_mask_strict
+    ( folder_id int4
+    , mask_name text
+    , maskitem_name text
+    , type text
+    , name text
+    , attribute_tests api.attribute_test[]
+    ) is
+    '@deprecated '
+    'Experimental version of function all_documents_facet_by_mask, '
+    'having the appropriate parameters marked as required. '
+    'Performance may be degraded. '
+;
+

--- a/backend/src/sql/api-facets.sql
+++ b/backend/src/sql/api-facets.sql
@@ -4,9 +4,9 @@
 
 create or replace function api.all_documents_docset
     ( folder_id int4
-    , type text
-    , name text
-    , attribute_tests api.attribute_test[]
+    , type text default 'use null instead of this surrogate dummy'
+    , name text default 'use null instead of this surrogate dummy'
+    , attribute_tests api.attribute_test[] default '{}'
     )
     returns api.docset as $$
     declare res api.docset;
@@ -18,13 +18,13 @@ create or replace function api.all_documents_docset
         from entity.document
         join aux.node_lineage on document.id = node_lineage.descendant
         where folder_id = node_lineage.ancestor
-        and (all_documents_docset.type is null or document.type = all_documents_docset.type)
-        and (all_documents_docset.name is null or document.name = all_documents_docset.name)
+        and (all_documents_docset.type = 'use null instead of this surrogate dummy' or document.type = all_documents_docset.type)
+        and (all_documents_docset.name = 'use null instead of this surrogate dummy' or document.name = all_documents_docset.name)
         and (attribute_tests is null or aux.jsonb_test_list (document.attrs, attribute_tests))
         ;
         return res;
     end;
-$$ language plpgsql stable parallel safe;
+$$ language plpgsql strict stable parallel safe;
 
 
 comment on function api.all_documents_docset (folder_id int4, type text, name text, attribute_tests api.attribute_test[]) is
@@ -79,7 +79,7 @@ $$ language plpgsql stable parallel safe;
 create or replace function api.fts_documents_docset
     ( folder_id int4
     , text text
-    , attribute_tests api.attribute_test[]
+    , attribute_tests api.attribute_test[] default '{}'
     )
     returns api.docset
     as $$ 
@@ -90,7 +90,7 @@ create or replace function api.fts_documents_docset
           , attribute_tests
           );
     end;
-$$ language plpgsql stable parallel safe;
+$$ language plpgsql strict stable parallel safe;
 
 comment on function api.fts_documents_docset
     ( folder_id int4

--- a/backend/src/sql/api-facets.sql
+++ b/backend/src/sql/api-facets.sql
@@ -322,7 +322,7 @@ comment on function api.all_documents_facet_by_key_strict
     , attribute_tests api.attribute_test[]
     ) is
     '@deprecated '
-    'Experimental version of function all_documents_facet_by_key, '
+    'Experimental version of function allDocumentsFacetByKey, '
     'having the appropriate parameters marked as required. '
 ;
 
@@ -405,7 +405,7 @@ comment on function api.all_documents_facet_by_mask_strict
     , attribute_tests api.attribute_test[]
     ) is
     '@deprecated '
-    'Experimental version of function all_documents_facet_by_mask, '
+    'Experimental version of function allDocumentsFacetByMask, '
     'having the appropriate parameters marked as required. '
     'Performance may be degraded. '
 ;

--- a/backend/src/sql/api-folder.sql
+++ b/backend/src/sql/api-folder.sql
@@ -22,7 +22,7 @@ create or replace function api.folder_by_id (id int4)
     returns api.folder as $$
     select * from entity.folder
     where entity.folder.id = folder_by_id.id
-$$ language sql stable;
+$$ language sql strict stable;
 
 comment on function api.folder_by_id (id int4) is
     'Gets a folder by its mediaTUM node id.';

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -123,7 +123,7 @@ $$ language plpgsql stable parallel safe rows 100;
 create or replace function api.fts_documents_page
     ( folder_id int4
     , text text
-    , attribute_tests api.attribute_test[]
+    , attribute_tests api.attribute_test[] default '{}'
     , sorting api.fts_sorting default 'by_rank'
     , "limit" integer default 10
     , "offset" integer default 0
@@ -150,14 +150,14 @@ create or replace function api.fts_documents_page
                 from search_result
             ) as content
         ;
-$$ language sql stable parallel safe;
+$$ language sql strict stable parallel safe;
 
 -- The same function as plpgsql
 -- Performance behavior seems to be the same.
 create or replace function api.fts_documents_page_pl
     ( folder_id int4
     , text text
-    , attribute_tests api.attribute_test[]
+    , attribute_tests api.attribute_test[] default '{}'
     , sorting api.fts_sorting default 'by_rank'
     , "limit" integer default 10
     , "offset" integer default 0
@@ -188,7 +188,7 @@ create or replace function api.fts_documents_page_pl
         ;
         return res;
     end;
-$$ language plpgsql stable parallel safe;
+$$ language plpgsql strict stable parallel safe;
 
 
 comment on function api.fts_documents_page (folder_id int4, text text, attribute_tests api.attribute_test[], sorting api.fts_sorting, "limit" integer, "offset" integer) is
@@ -218,7 +218,7 @@ create or replace function api.author_search (folder_id int4, text text)
             replace (node.attrs ->> 'author.surname', ';', ' ')
           )
           @@ tsq;
-$$ language sql stable rows 100 parallel safe;
+$$ language sql strict stable rows 100 parallel safe;
 
 comment on function api.author_search (folder_id int4, text text) is
     'Reads and enables pagination through all documents within a folder, filtered by a keyword search though the documents'' author.';

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -135,7 +135,7 @@ create or replace function api.fts_documents_page
                 from aux.fts_documents_paginated
                     ( folder_id
                     , text
-                    , attribute_tests
+                    , nullif(attribute_tests, '{}')
                     , sorting
                     , "limit", "offset"
                     )
@@ -187,7 +187,7 @@ create or replace function api.fts_documents_page_pl
             aux.fts_documents_paginated
                 ( folder_id
                 , text
-                , attribute_tests
+                , nullif(attribute_tests, '{}')
                 , sorting
                 , "limit", "offset"
                 )

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -152,6 +152,12 @@ create or replace function api.fts_documents_page
         ;
 $$ language sql strict stable parallel safe;
 
+comment on function api.fts_documents_page (folder_id int4, text text, attribute_tests api.attribute_test[], sorting api.fts_sorting, "limit" integer, "offset" integer) is
+    'Perform a full-text-search on the documents of a folder, sorted by a search rank, optionally filtered by type and name and a list of attribute tests.'
+    ' Sorting of the results is either "by_rank" (default) or "by_date".'
+    ' For pagination you may specify a limit (defaults to 10) and an offset (defaults to 0).'
+    ;
+
 -- The same function as plpgsql
 -- Performance behavior seems to be the same.
 create or replace function api.fts_documents_page_pl
@@ -190,9 +196,9 @@ create or replace function api.fts_documents_page_pl
     end;
 $$ language plpgsql strict stable parallel safe;
 
-
-comment on function api.fts_documents_page (folder_id int4, text text, attribute_tests api.attribute_test[], sorting api.fts_sorting, "limit" integer, "offset" integer) is
-    'Perform a full-text-search on the documents of a folder, sorted by a search rank, optionally filtered by type and name and a list of attribute tests.'
+comment on function api.fts_documents_page_pl (folder_id int4, text text, attribute_tests api.attribute_test[], sorting api.fts_sorting, "limit" integer, "offset" integer) is
+    'Alternative implementation of ftsDocumentsPage; may have different perfoamce behavior. '
+    ' Perform a full-text-search on the documents of a folder, sorted by a search rank, optionally filtered by type and name and a list of attribute tests.'
     ' Sorting of the results is either "by_rank" (default) or "by_date".'
     ' For pagination you may specify a limit (defaults to 10) and an offset (defaults to 0).'
     ;

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -197,6 +197,7 @@ create or replace function api.fts_documents_page_pl
 $$ language plpgsql strict stable parallel safe;
 
 comment on function api.fts_documents_page_pl (folder_id int4, text text, attribute_tests api.attribute_test[], sorting api.fts_sorting, "limit" integer, "offset" integer) is
+    '@deprecated '
     'Alternative implementation of ftsDocumentsPage; may have different perfoamce behavior. '
     ' Perform a full-text-search on the documents of a folder, sorted by a search rank, optionally filtered by type and name and a list of attribute tests.'
     ' Sorting of the results is either "by_rank" (default) or "by_date".'

--- a/backend/src/sql/api-meta.sql
+++ b/backend/src/sql/api-meta.sql
@@ -27,7 +27,7 @@ create or replace function api.metadatatype_by_name (name text)
     returns api.metadatatype as $$
     select * from entity.metadatatype
     where entity.metadatatype.name = metadatatype_by_name.name
-$$ language sql stable;
+$$ language sql strict stable;
 
 comment on function api.metadatatype_by_name (name text) is
     'Gets a meta data type by its name.';
@@ -122,7 +122,7 @@ create or replace function api.mapping_by_name (name text)
     returns api.mapping as $$
     select * from entity.mapping
     where entity.mapping.name = mapping_by_name.name
-$$ language sql stable;
+$$ language sql strict stable;
 
 comment on function api.mapping_by_name (name text) is
     'Gets a mapping by its name.';
@@ -284,7 +284,7 @@ create or replace function api.metadatatype_metafield_by_name (mdt api.metadatat
     select * from entity.metafield
     where metafield.metadatatype_id = mdt.id
       and metafield.name = metadatatype_metafield_by_name.name
-$$ language sql stable;
+$$ language sql strict stable;
 
 comment on function api.metadatatype_metafield_by_name (mdt api.metadatatype, name text) is
     'Gets a meta field of this meta data type by name.';
@@ -324,7 +324,7 @@ create or replace function api.metadatatype_mask_by_name (mdt api.metadatatype, 
     select * from entity.mask
     where mask.metadatatype_id = mdt.id
       and mask.name = metadatatype_mask_by_name.name
-$$ language sql stable;
+$$ language sql strict stable;
 
 comment on function api.metadatatype_mask_by_name (mdt api.metadatatype, name text) is
     'Gets a mask of this meta data type by name.';
@@ -344,7 +344,7 @@ create or replace function api.mask_maskitems (mask api.mask, type text, fieldty
 $$ language sql stable rows 80;
 
 comment on function api.mask_maskitems (mask api.mask, type text, fieldtype text, is_required boolean, find text) is
-    'Reads and enables pagination through all items this mask, optionally filtered by type, fieldtype and is_required, and searchable by name.';
+    'Reads and enables pagination through all items of this mask, optionally filtered by type, fieldtype and is_required, and searchable by name.';
 
 
 create or replace function api.mask_maskitem_by_name (mask api.mask, name text)
@@ -352,7 +352,7 @@ create or replace function api.mask_maskitem_by_name (mask api.mask, name text)
     select * from entity.maskitem
     where maskitem.parent_id = mask.id
       and maskitem.name = mask_maskitem_by_name.name
-$$ language sql stable;
+$$ language sql strict stable;
 
 comment on function api.mask_maskitem_by_name (mask api.mask, name text) is
     'Gets an item of this mask by name.';
@@ -379,7 +379,7 @@ create or replace function api.maskitem_subitem_by_name (parent api.maskitem, na
     select * from entity.maskitem
     where maskitem.parent_id = parent.id
       and maskitem.name = maskitem_subitem_by_name.name
-$$ language sql stable;
+$$ language sql strict stable;
 
 comment on function api.maskitem_subitem_by_name (parent api.maskitem, name text) is
     'Gets a sub-item of this mask item by name.';
@@ -507,7 +507,7 @@ create or replace function api.mapping_mappingfield_by_name(m api.mapping, name 
     select * from entity.mappingfield
     where mappingfield.mapping_id = m.id
       and mappingfield.name = mapping_mappingfield_by_name.name
-$$ language sql stable;
+$$ language sql strict stable;
 
 comment on function api.mapping_mappingfield_by_name(m api.mapping, name text) is
     'Gets a mapping field of this mapping by name.';

--- a/backend/src/sql/api-mutation.sql
+++ b/backend/src/sql/api-mutation.sql
@@ -15,7 +15,7 @@ create or replace function api.update_document_attribute (id int4, key text, val
     and attrs ? key 
     returning *
 
-$$ language sql volatile;
+$$ language sql strict volatile;
 
 comment on function api.update_document_attribute (id int4, key text, value text) is
     'Updates an existing attribute of the document with the given id.';

--- a/backend/src/sql/api-node.sql
+++ b/backend/src/sql/api-node.sql
@@ -8,7 +8,7 @@ create or replace function api.generic_node_by_id (id int4)
     select node.id
     from entity.node
     where entity.node.id = generic_node_by_id.id
-$$ language sql stable;
+$$ language sql strict stable;
 
 comment on function api.generic_node_by_id (id int4) is
     'Gets a generic node by its mediaTUM node id.';

--- a/backend/src/sql/debug.sql
+++ b/backend/src/sql/debug.sql
@@ -35,7 +35,7 @@ create or replace function debug.node_by_id (id int4)
     select id, type, schema, name, orderpos, fulltext, subnode
     from mediatum.node
     where node.id = node_by_id.id
-$$ language sql stable;
+$$ language sql strict stable;
 
 
 create or replace function debug.mediatum_node_attributes (node debug.mediatum_node, keys text[])

--- a/frontend/src/elm/Api/Fragments.elm
+++ b/frontend/src/elm/Api/Fragments.elm
@@ -236,10 +236,10 @@ facetByKey key limit =
             (Mediatum.Object.Docset.facetByKey
                 (\optionals ->
                     { optionals
-                        | key = Present key
-                        , first = Present limit
+                        | first = Present limit
                     }
                 )
+                { key = key }
                 facetValues
             )
 

--- a/frontend/src/elm/Api/Mutations.elm
+++ b/frontend/src/elm/Api/Mutations.elm
@@ -15,6 +15,7 @@ import Graphql.Operation
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet)
 import Maybe.Extra
+import Mediatum.InputObject
 import Mediatum.Mutation
 import Mediatum.Object.UpdateDocumentAttributePayload
 import Types.Id as Id exposing (DocumentId)
@@ -48,11 +49,12 @@ updateDocumentAttribute documentId key value =
     SelectionSet.map Maybe.Extra.join
         (Mediatum.Mutation.updateDocumentAttribute
             { input =
-                { clientMutationId = Absent
-                , id = Present (Id.toInt documentId)
-                , key = Present key
-                , value = Present value
-                }
+                Mediatum.InputObject.buildUpdateDocumentAttributeInput
+                    { id = Id.toInt documentId
+                    , key = key
+                    , value = value
+                    }
+                    identity
             }
             (SelectionSet.succeed identity
                 |> SelectionSet.with

--- a/frontend/src/elm/Api/Queries.elm
+++ b/frontend/src/elm/Api/Queries.elm
@@ -347,6 +347,7 @@ _GraphQL notation:_
 
     query {
         authorSearch(
+            folderId: $folderId
             text: $searchTerm
             first: $optionalRelayPaginationArgument
             last: $optionalRelayPaginationArgument


### PR DESCRIPTION
Field-arguments that are semantically required should be marked as such (i.e. not nullable) in the API.

As an example, `ftsDocumentsPage` has two required arguments (note the "!" in the type) and four optional arguments:

```graphql
ftsDocumentsPage
    (folderId: Int!
    , text: String!
    , attributeTests: [AttributeTestInput]
    , sorting: FtsSorting
    , limit: Int
    , offset: Int
    ): DocumentResultPage
```

In PostGraphile this is realized by annotating the SQL function as `strict` and using default arguments for the optional parameters. See https://github.com/graphile/postgraphile/issues/438

Please note:
- PostgreSQL cannot inline strict functions in most cases.
  So in order not to impair the performance we should not mark functions as strict that are used in inner-loops.
- Null cannot sensible be used as a default value of a strict function.
  In cases where we need to pass null to the implementation of the function we use a (otherwise unused) dummy value as a surrogate default value. (Not possible for type boolean unfortunately.)
