### PR TITLE
Sort documents by nodeid in descending order

### DIFF
--- a/backend/src/sql/api-document.sql
+++ b/backend/src/sql/api-document.sql
@@ -20,7 +20,7 @@ create or replace function aux.all_documents_limited
     and (all_documents_limited.type is null or document.type = all_documents_limited.type)
     and (all_documents_limited.name is null or document.name = all_documents_limited.name)
     and (attribute_tests is null or aux.jsonb_test_list (document.attrs, attribute_tests))
-    order by document.id
+    order by document.id desc
     limit "limit"
     ;
 $$ language sql stable rows 100;

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -50,6 +50,8 @@ create or replace function aux.fts_documents_limited
            where ufts.tsvec @@ fts_query
            
            order by
+               -- The operators <=| and <=> are provided by the RUM extension.
+               -- See https://github.com/postgrespro/rum#common-operators-and-functions
                case when sorting = 'by_date' then ufts.year <=| 2147483647
                     when sorting = 'by_rank' then ufts.tsvec <=> fts_query
                end,

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -50,8 +50,10 @@ create or replace function aux.fts_documents_limited
            where ufts.tsvec @@ fts_query
            
            order by
-                case when sorting = 'by_date' then ufts.year <=| 2147483647 end,
-                case when sorting = 'by_rank' then ufts.tsvec <=> fts_query end
+                ( case when sorting = 'by_date' then ufts.year <=| 2147483647 end
+                , case when sorting = 'by_rank' then ufts.tsvec <=> fts_query end
+                )
+                , ufts.nid desc
            
          ) as fts
     join entity.document on document.id = fts.id
@@ -74,8 +76,10 @@ create or replace function aux.fts_documents_limited
 
     -- For now we sort here once again.
     order by
-        case when sorting = 'by_date' then fts.year <=| 2147483647 end,
-        case when sorting = 'by_rank' then fts.distance end
+        ( case when sorting = 'by_date' then fts.year <=| 2147483647 end
+        , case when sorting = 'by_rank' then fts.distance end
+        )
+        , fts.id desc
     
     limit "limit"
     ;

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -50,10 +50,10 @@ create or replace function aux.fts_documents_limited
            where ufts.tsvec @@ fts_query
            
            order by
-                ( case when sorting = 'by_date' then ufts.year <=| 2147483647 end
-                , case when sorting = 'by_rank' then ufts.tsvec <=> fts_query end
-                )
-                , ufts.nid desc
+               case when sorting = 'by_date' then ufts.year <=| 2147483647
+                    when sorting = 'by_rank' then ufts.tsvec <=> fts_query
+               end,
+               ufts.nid desc
            
          ) as fts
     join entity.document on document.id = fts.id
@@ -76,10 +76,10 @@ create or replace function aux.fts_documents_limited
 
     -- For now we sort here once again.
     order by
-        ( case when sorting = 'by_date' then fts.year <=| 2147483647 end
-        , case when sorting = 'by_rank' then fts.distance end
-        )
-        , fts.id desc
+        case when sorting = 'by_date' then fts.year <=| 2147483647 
+             when sorting = 'by_rank' then fts.distance
+        end,
+        fts.id desc
     
     limit "limit"
     ;


### PR DESCRIPTION
When listing directories newer documents should come first.

We don't use the `year` attribute because it is too coarse.

We rather us the `nodeid` in descending order.
This corresponds approximately to the order in which the data is entered into the database.

Similar, when listing FTS results ordered by year we now also use `nodeid` as an additional sort criterion.