### PR TITLE
FTS ordered by date now uses nodeid as sort criterion

### DIFF
--- a/backend/src/sql/api-document.sql
+++ b/backend/src/sql/api-document.sql
@@ -37,6 +37,7 @@ create or replace function aux.all_documents_paginated
     returns table
         ( document api.document
         , distance float4
+        , recency int4
         , year int4
         , number integer
         , has_next_page boolean
@@ -46,6 +47,7 @@ create or replace function aux.all_documents_paginated
             return query
             select f
                 , 0.0::float4
+                , - f.id -- Same definition of "recency" as in table proprocess.ufts!
                 , preprocess.year_from_attrs (f.attrs)
                 , (row_number () over ())::integer as number
                 , (count(*) over ()) > "limit" + "offset"
@@ -88,7 +90,7 @@ create or replace function api.all_documents_page
                 (select every(has_next_page) from search_result), false
             ) as has_next_page,
             array (
-            select row(number, distance, year, document)::api.document_result
+            select row(number, distance, recency, year, document)::api.document_result
                 from search_result
             ) as content
         ;

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -54,7 +54,7 @@ create or replace function aux.fts_documents_limited
            order by
                -- The operators |=> and <=> are provided by the RUM extension.
                -- See https://github.com/postgrespro/rum#common-operators-and-functions
-               case when sorting = 'by_date' then ufts.recency |=> 2147483647
+               case when sorting = 'by_date' then ufts.recency |=> -2147483647
                     when sorting = 'by_rank' then ufts.tsvec <=> fts_query
                end
            
@@ -79,7 +79,7 @@ create or replace function aux.fts_documents_limited
 
     -- For now we sort here once again.
     order by
-        case when sorting = 'by_date' then fts.recency |=> 2147483647 
+        case when sorting = 'by_date' then fts.recency |=> -2147483647 
              when sorting = 'by_rank' then fts.distance
         end
     

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -35,27 +35,29 @@ create or replace function aux.fts_documents_limited
     returns table
         ( document api.document
         , distance float4
+        , recency int4
         , year int4
         )
     as $$
     select
         (document.id, document.type, document.schema, document.name, document.orderpos, document.attrs)::api.document as document,
         fts.distance,
+        fts.recency,
         year
     from (select ufts.nid as id
                , ufts.tsvec <=> fts_query as distance
+               , ufts.recency as recency
                , ufts.year as year
                , (count(*) over ())::integer
            from preprocess.ufts
            where ufts.tsvec @@ fts_query
            
            order by
-               -- The operators <=| and <=> are provided by the RUM extension.
+               -- The operators |=> and <=> are provided by the RUM extension.
                -- See https://github.com/postgrespro/rum#common-operators-and-functions
-               case when sorting = 'by_date' then ufts.year <=| 2147483647
+               case when sorting = 'by_date' then ufts.recency |=> 2147483647
                     when sorting = 'by_rank' then ufts.tsvec <=> fts_query
-               end,
-               ufts.nid desc
+               end
            
          ) as fts
     join entity.document on document.id = fts.id
@@ -78,10 +80,10 @@ create or replace function aux.fts_documents_limited
 
     -- For now we sort here once again.
     order by
-        case when sorting = 'by_date' then fts.year <=| 2147483647 
+        case when sorting = 'by_date' then fts.recency |=> 2147483647 
              when sorting = 'by_rank' then fts.distance
-        end,
-        fts.id desc
+        end
+    
     
     limit "limit"
     ;
@@ -102,6 +104,7 @@ create or replace function aux.fts_documents_paginated
     returns table
         ( document api.document
         , distance float4
+        , recency int4
         , year int4
         , number integer
         , has_next_page boolean
@@ -110,6 +113,7 @@ create or replace function aux.fts_documents_paginated
         begin return query
             select f.document
                 , f.distance
+                , f.recency
                 , f.year
                 , (row_number () over ())::integer as number
                 , (count(*) over ()) > "limit" + "offset"
@@ -152,7 +156,7 @@ create or replace function api.fts_documents_page
                 (select every(has_next_page) from search_result), false
             ) as has_next_page,
             array (
-            select row(number, distance, year, document)::api.document_result
+            select row(number, distance, recency, year, document)::api.document_result
                 from search_result
             ) as content
         ;

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -48,7 +48,6 @@ create or replace function aux.fts_documents_limited
                , ufts.tsvec <=> fts_query as distance
                , ufts.recency as recency
                , ufts.year as year
-               , (count(*) over ())::integer
            from preprocess.ufts
            where ufts.tsvec @@ fts_query
            

--- a/backend/src/sql/preprocess.sql
+++ b/backend/src/sql/preprocess.sql
@@ -76,6 +76,11 @@ insert into preprocess.ufts (nid, "year", recency, tsvec)
 -- Reset message level to default
 set session client_min_messages to notice;
 
+-- Index for queryies ordered by distance between tsvector and tsquery
+create index if not exists ufts_rum_tsvector_ops
+    on preprocess.ufts
+ using rum (tsvec rum_tsvector_ops);
+
 -- Index for queryies ordered by recency
 create index if not exists ufts_rum_tsvector_addon_ops
     on preprocess.ufts

--- a/backend/src/sql/types.sql
+++ b/backend/src/sql/types.sql
@@ -304,6 +304,7 @@ comment on column api.attribute_test.extra is
 create type api.document_result as (
     number integer,
     distance float4,
+    recency int4,
     year int4,
     document api.document
 );
@@ -314,6 +315,9 @@ comment on column api.document_result.number is
     'Sequence number of this result';
 comment on column api.document_result.distance is
     'A measure of the relevance of this result with respect to the query expression; lower values means higher relevance';
+comment on column api.document_result.recency is
+    'A measure for the actuality of this result. '
+    'Currently the negative value of the nodeid is used as an approximation of the recency.';
 comment on column api.document_result.year is
     'Year of publication, used for chronological sorting';
 comment on column api.document_result.document is


### PR DESCRIPTION
Analog to directory listings (see #36).

We add an additional column `recency` to table `preprocess.ufts`
and build a RUM index `using rum (tsvec rum_tsvector_addon_ops, recency)` for FTS queries ordered `by_date`.