### PR TITLE
Instrumentalize elm-tooling

### DIFF
--- a/frontend/elm-tooling.json
+++ b/frontend/elm-tooling.json
@@ -1,0 +1,10 @@
+{
+    "entrypoints": [
+        "./src/elm/Main.elm"
+    ],
+    "tools": {
+        "elm": "0.19.1",
+        "elm-format": "0.8.4",
+        "elm-json": "0.2.8"
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -345,14 +345,6 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
-    "elm": {
-      "version": "0.19.1-3",
-      "resolved": "https://registry.npmjs.org/elm/-/elm-0.19.1-3.tgz",
-      "integrity": "sha512-6y36ewCcVmTOx8lj7cKJs3bhI5qMfoVEigePZ9PhEUNKpwjjML/pU2u2YSpHVAznuCcojoF6KIsrS1Ci7GtVaQ==",
-      "requires": {
-        "request": "^2.88.0"
-      }
-    },
     "elm-hot": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/elm-hot/-/elm-hot-1.1.4.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -503,6 +503,12 @@
         }
       }
     },
+    "elm-tooling": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/elm-tooling/-/elm-tooling-0.4.1.tgz",
+      "integrity": "sha512-wjWDEscceq58Ap1kOQgTU332QdzVVEWWGdFhfTl470kv06GMmMSBDv/+ANYnofqTbNwZ3Uw+9HxSM/QT4lIzAA==",
+      "dev": true
+    },
     "elmi-to-json": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/elmi-to-json/-/elmi-to-json-1.3.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Web app as a client for the GraphQL API of mediaTUM",
   "scripts": {
-    "install-elm-tooling": "elm-tooling install",
+    "postinstall": "elm-tooling install",
     "test": "elm-test",
     "test-watch": "elm-test --watch",
     "generate": "rimraf gen && elm-graphql http://localhost:5000/graphql --base Mediatum --output gen/",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Web app as a client for the GraphQL API of mediaTUM",
   "scripts": {
+    "install-elm-tooling": "elm-tooling install",
     "test": "elm-test",
     "test-watch": "elm-test --watch",
     "generate": "rimraf gen && elm-graphql http://localhost:5000/graphql --base Mediatum --output gen/",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@dillonkearns/elm-graphql": "^4.0.3",
-    "elm": "^0.19.1-3",
     "ncp": "^2.0.0",
     "rimraf": "^3.0.2"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,8 @@
   "homepage": "https://github.com/ThomasWeiser/mediatum-view#readme",
   "devDependencies": {
     "elm-live": "^4.0.2",
-    "elm-test": "^0.19.1-revision2"
+    "elm-test": "^0.19.1-revision2",
+    "elm-tooling": "^0.4.1"
   },
   "dependencies": {
     "@dillonkearns/elm-graphql": "^4.0.3",


### PR DESCRIPTION
Added `frontend/elm-tooling.json`,
which is used by elm-language-server,
which is used by the VSCode plugin elmtooling.elm-ls-vscode.

There is now a postinstall script run on `npm install`, which will run `elm-tooling install`, which installs the tools listed in `elm-tooling.json` to `~/.elm/elm-tooling`.

Currently these tools are 
- `elm`, i.e. the Elm compiler (which therefore no longer goes into `node_modules/elm`)
- `elm-format`

References:
https://github.com/lydell/elm-tooling.json
https://github.com/elm-tooling/elm-language-server
https://github.com/elm-tooling/elm-language-client-vscode
https://marketplace.visualstudio.com/items?itemName=Elmtooling.elm-ls-vscode
