### PR TITLE
Fix backend: subfolderCounts

### DIFF
--- a/backend/src/sql/api-facets.sql
+++ b/backend/src/sql/api-facets.sql
@@ -113,7 +113,7 @@ create or replace function aux.subfolder_counts
     begin
         return query
             select
-              node_children,
+              folder.id,
               -- Counting in a sub-query together with `exists` is faster than
               -- counting with a group-by and together with `aux.test_node_lineage`
               -- TODO: Test if this is also true in case of a large number of sub-folders.
@@ -121,10 +121,11 @@ create or replace function aux.subfolder_counts
                     from unnest (docset.id_list) as document_id_rows
                     where exists ( select 1
                                   from mediatum.noderelation
-                                  where nid = node_children and cid = document_id_rows
+                                  where nid = folder.id and cid = document_id_rows
                                 )
               )::integer
-            from aux.node_children (coalesce (parent_folder_id, docset.folder_id))
+            from entity.folder
+            where folder.parent_id = coalesce (parent_folder_id, docset.folder_id)
         ;
     end;
 $$ language plpgsql stable parallel safe rows 50;

--- a/backend/src/sql/api-facets.sql
+++ b/backend/src/sql/api-facets.sql
@@ -102,14 +102,11 @@ comment on function api.fts_documents_docset
 ;
 
 
-create or replace function aux.subfolder_counts
+create or replace function api.docset_subfolder_counts
     ( docset api.docset
     , parent_folder_id int4 default null
     )
-    returns table
-        ( folder_id int4
-        , count integer
-        ) as $$
+    returns setof api.folder_count as $$
     begin
         return query
             select
@@ -130,19 +127,6 @@ create or replace function aux.subfolder_counts
     end;
 $$ language plpgsql stable parallel safe rows 50;
 
-
-create or replace function api.docset_subfolder_counts
-    ( docset api.docset
-    , parent_folder_id int4 -- default null
-    )
-    returns setof api.folder_count as $$
-    begin
-        return query
-            select *
-            from aux.subfolder_counts (docset, parent_folder_id)
-        ;
-    end;
-$$ language plpgsql stable parallel safe rows 50;
 
 comment on function api.docset_subfolder_counts
     ( docset api.docset


### PR DESCRIPTION
We had a bug when computing the `subfolderCounts` on a `docset`.

The query included not only the subfolder of the given parent folder of the docset.
It included also all other nodes (notably all documents) that a direct children of that parent folder.
