### PR TITLE
Format SQL code more consistently

### DIFF
--- a/backend/src/sql/api-document.sql
+++ b/backend/src/sql/api-document.sql
@@ -126,7 +126,9 @@ comment on function api.all_documents_page (folder_id int4, type text, name text
     'Reads and enables pagination through all documents in a folder, optionally filtered by type and name and a list of attribute tests';
 
 
-create or replace function api.document_by_id (id int4)
+create or replace function api.document_by_id
+    ( id int4
+    )
     returns api.document as $$
     select *
     from entity.document
@@ -137,7 +139,9 @@ comment on function api.document_by_id (id int4) is
     'Gets a document by its mediaTUM node id.';
 
 
-create or replace function api.document_folders (document api.document)
+create or replace function api.document_folders
+    ( document api.document
+    )
     returns api.folder[] as $$
     select array(
         select row(folder.*)::api.folder
@@ -152,7 +156,10 @@ comment on function api.document_folders (document api.document) is
     'Gets the list of all folders in which the document appears.';
 
 
-create or replace function api.document_attributes (document api.document, keys text[])
+create or replace function api.document_attributes
+    ( document api.document
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_document_attributes (document, keys)
 $$ language sql stable;
@@ -161,7 +168,10 @@ comment on function api.document_attributes (document api.document, keys text[])
     'Gets the node attributes of this document as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.document_system_attributes (document api.document, keys text[])
+create or replace function api.document_system_attributes
+    ( document api.document
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_system_attributes (document.id, keys)
 $$ language sql stable;
@@ -170,7 +180,9 @@ comment on function api.document_system_attributes (document api.document, keys 
     'Gets the node system attributes of this document as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.document_metadatatype (document api.document)
+create or replace function api.document_metadatatype
+    ( document api.document
+    )
     returns api.metadatatype as $$
     select api.metadatatype_by_name (document.schema)
 $$ language sql stable;
@@ -179,7 +191,11 @@ comment on function api.document_metadatatype (document api.document) is
     'Gets the meta data type of this document.';
 
 
-create or replace function api.metadatatype_documents (mdt api.metadatatype, type text, name text)
+create or replace function api.metadatatype_documents
+    ( mdt api.metadatatype
+    , type text
+    , name text
+    )
     returns setof api.document as $$
     select document.*
     from entity.node as document
@@ -192,7 +208,10 @@ comment on function api.metadatatype_documents (mdt api.metadatatype, type text,
     'Reads and enables pagination through all documents having this meta data type, optionally filtered by type and name.';
 
 
-create or replace function api.document_values_by_mask (document api.document, mask_name text)
+create or replace function api.document_values_by_mask
+    ( document api.document
+    , mask_name text
+    )
     returns jsonb as $$
     select v.values
     from entity.document_mask_value_list as v

--- a/backend/src/sql/api-folder.sql
+++ b/backend/src/sql/api-folder.sql
@@ -3,7 +3,14 @@
 -- regarding folders (i.e. collections and directories).
 
 
-create or replace function api.all_folders (name text, ids int4[], parent_ids int4[], is_root boolean, is_collection boolean, find text)
+create or replace function api.all_folders
+    ( name text
+    , ids int4[]
+    , parent_ids int4[]
+    , is_root boolean
+    , is_collection boolean
+    , find text
+    )
     returns setof api.folder as $$
     select * from entity.folder
     where (all_folders.name is null or folder.name = all_folders.name)
@@ -20,7 +27,9 @@ comment on function api.all_folders (name text, ids int4[], parent_ids int4[], i
     ' optionally filtered by name, list of ids, list of parentIds, isRoot and isCollection, and searchable by name.';
 
 
-create or replace function api.folder_by_id (id int4)
+create or replace function api.folder_by_id
+    ( id int4
+    )
     returns api.folder as $$
     select * from entity.folder
     where entity.folder.id = folder_by_id.id
@@ -30,7 +39,12 @@ comment on function api.folder_by_id (id int4) is
     'Gets a folder by its mediaTUM node id.';
 
 
-create or replace function api.folder_subfolders (parent api.folder, name text, is_collection boolean, find text)
+create or replace function api.folder_subfolders
+    ( parent api.folder
+    , name text
+    , is_collection boolean
+    , find text
+    )
     returns setof api.folder as $$
     select * from entity.folder
     where folder.parent_id = parent.id
@@ -44,7 +58,9 @@ comment on function api.folder_subfolders (parent api.folder, name text, is_coll
     'Reads and enables pagination through all sub-folders of this folder, optionally filtered by name and isCollection, and searchable by name.';
 
 
-create or replace function api.folder_superfolder (child api.folder)
+create or replace function api.folder_superfolder
+    ( child api.folder
+    )
     returns api.folder as $$
     select * from entity.folder
     where folder.id = child.parent_id
@@ -54,7 +70,9 @@ comment on function api.folder_superfolder (child api.folder) is
     'Gets the super-folder of this folder. Returns null if this folder is at the root.';
 
 
-create or replace function api.folder_lineage (current_folder api.folder)
+create or replace function api.folder_lineage
+    ( current_folder api.folder
+    )
     returns api.folder[] as $$
     declare lineage api.folder[] := array[current_folder];
     begin

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -299,7 +299,10 @@ comment on function api.fts_documents_page (folder_id int4, text text, attribute
 ----------------------------------------------------
 
 
-create or replace function api.author_search (folder_id int4, text text)
+create or replace function api.author_search
+    ( folder_id int4
+    , text text
+    )
     returns setof api.document as $$
     select
         node.id,

--- a/backend/src/sql/api-meta.sql
+++ b/backend/src/sql/api-meta.sql
@@ -11,7 +11,11 @@ TODO: Quick and dirty pattern matching ahead. Needs more elaboration:
 */      
 
 
-create or replace function api.all_metadatatypes (bibtexmapping text, citeprocmapping text, find text)
+create or replace function api.all_metadatatypes
+    ( bibtexmapping text
+    , citeprocmapping text
+    , find text
+    )
     returns setof api.metadatatype as $$
     select * from entity.metadatatype
     where (all_metadatatypes.bibtexmapping is null or metadatatype.bibtexmapping = all_metadatatypes.bibtexmapping)
@@ -23,7 +27,9 @@ comment on function api.all_metadatatypes (bibtexmapping text, citeprocmapping t
     'Reads and enables pagination through all meta data types, optionally filtered by bibtexmapping and citeprocmapping, and searchable by longname.';
 
 
-create or replace function api.metadatatype_by_name (name text)
+create or replace function api.metadatatype_by_name
+    ( name text
+    )
     returns api.metadatatype as $$
     select * from entity.metadatatype
     where entity.metadatatype.name = metadatatype_by_name.name
@@ -33,7 +39,11 @@ comment on function api.metadatatype_by_name (name text) is
     'Gets a meta data type by its name.';
 
 
-create or replace function api.all_metafields (name text, type text, find text)
+create or replace function api.all_metafields
+    ( name text
+    , type text
+    , find text
+    )
     returns setof api.metafield as $$
     select * from entity.metafield
     where (all_metafields.name is null or metafield.name = all_metafields.name)
@@ -50,7 +60,14 @@ comment on function api.all_metafields (name text, type text, find text) is
     'Reads and enables pagination through all meta fields, optionally filtered by name and type, and searchable by name, label and description.';
 
 
-create or replace function api.all_masks (name text, masktype text, language text, is_default boolean, is_vgroup boolean, find text)
+create or replace function api.all_masks
+    ( name text
+    , masktype text
+    , language text
+    , is_default boolean
+    , is_vgroup boolean
+    , find text
+    )
     returns setof api.mask as $$
     select * from entity.mask
     where (all_masks.name is null or mask.name = all_masks.name)
@@ -69,7 +86,13 @@ comment on function api.all_masks (name text, masktype text, language text, is_d
     'Reads and enables pagination through all masks, optionally filtered by name, masktype, language, is_default, is_vgroup, and searchable by name and description.';
 
 
-create or replace function api.all_maskitems (name text, type text, fieldtype text, is_required boolean, find text)
+create or replace function api.all_maskitems
+    ( name text
+    , type text
+    , fieldtype text
+    , is_required boolean
+    , find text
+    )
     returns setof api.maskitem as $$
     select * from entity.maskitem
     where (all_maskitems.name is null or maskitem.name = all_maskitems.name)
@@ -86,7 +109,13 @@ comment on function api.all_maskitems (name text, type text, fieldtype text, is_
     'Reads and enables pagination through all mask items, optionally filtered by name, type, fieldtype and is_required, and searchable by name.';
 
 
-create or replace function api.all_maskitem_reachable (name text, type text, fieldtype text, is_required boolean, find text)
+create or replace function api.all_maskitem_reachable
+    ( name text
+    , type text
+    , fieldtype text
+    , is_required boolean
+    , find text
+    )
     returns setof api.maskitem_reachable as $$
     select * from entity.maskitem_recursive
     where (all_maskitem_reachable.name is null or maskitem_recursive.name = all_maskitem_reachable.name)
@@ -103,7 +132,10 @@ comment on function api.all_maskitem_reachable (name text, type text, fieldtype 
     'Reads and enables pagination through all mask items (alternative implementation), optionally filtered by name, type, fieldtype and is_required, and searchable by name.';
 
 
-create or replace function api.all_mappings (type text, find text)
+create or replace function api.all_mappings
+    ( type text
+    , find text
+    )
     returns setof api.mapping as $$
     select * from entity.mapping
     where (all_mappings.type is null or mapping.type = all_mappings.type)
@@ -118,7 +150,9 @@ comment on function api.all_mappings (type text, find text) is
     'Reads and enables pagination through all mappings, optionally filtered by type, and searchable by name and description.';
 
 
-create or replace function api.mapping_by_name (name text)
+create or replace function api.mapping_by_name
+    ( name text
+    )
     returns api.mapping as $$
     select * from entity.mapping
     where entity.mapping.name = mapping_by_name.name
@@ -128,7 +162,11 @@ comment on function api.mapping_by_name (name text) is
     'Gets a mapping by its name.';
 
 
-create or replace function api.all_mappingfields (name text, is_mandatory boolean, find text)
+create or replace function api.all_mappingfields
+    ( name text
+    , is_mandatory boolean
+    , find text
+    )
     returns setof api.mappingfield as $$
     select * from entity.mappingfield
     where (all_mappingfields.name is null or mappingfield.name = all_mappingfields.name)
@@ -144,7 +182,10 @@ comment on function api.all_mappingfields (name text, is_mandatory boolean, find
     'Reads and enables pagination through all mapping fields, optionally filtered by name and is_mandatory, and searchable by name and description.';
 
 
-create or replace function api.metadatatype_attributes (mdt api.metadatatype, keys text[])
+create or replace function api.metadatatype_attributes
+    ( mdt api.metadatatype
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_attributes (mdt.id, keys)
 $$ language sql stable;
@@ -153,7 +194,10 @@ comment on function api.metadatatype_attributes (mdt api.metadatatype, keys text
     'Gets the node attributes of this meta data type as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.metadatatype_system_attributes (mdt api.metadatatype, keys text[])
+create or replace function api.metadatatype_system_attributes
+    ( mdt api.metadatatype
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_system_attributes (mdt.id, keys)
 $$ language sql stable;
@@ -162,7 +206,10 @@ comment on function api.metadatatype_system_attributes (mdt api.metadatatype, ke
     'Gets the node system attributes of this meta data type as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.metafield_attributes (metafield api.metafield, keys text[])
+create or replace function api.metafield_attributes
+    ( metafield api.metafield
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_attributes (metafield.id, keys)
 $$ language sql stable;
@@ -171,7 +218,10 @@ comment on function api.metafield_attributes (metafield api.metafield, keys text
     'Gets the node attributes of this meta field as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.metafield_system_attributes (metafield api.metafield, keys text[])
+create or replace function api.metafield_system_attributes
+    ( metafield api.metafield
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_system_attributes (metafield.id, keys)
 $$ language sql stable;
@@ -180,7 +230,10 @@ comment on function api.metafield_system_attributes (metafield api.metafield, ke
     'Gets the node system attributes of this meta field as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.mask_attributes (mask api.mask, keys text[])
+create or replace function api.mask_attributes
+    (  mask api.mask
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_attributes (mask.id, keys)
 $$ language sql stable;
@@ -189,7 +242,10 @@ comment on function api.mask_attributes (mask api.mask, keys text[]) is
     'Gets the node attributes of this mask as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.mask_system_attributes (mask api.mask, keys text[])
+create or replace function api.mask_system_attributes
+    ( mask api.mask
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_system_attributes (mask.id, keys)
 $$ language sql stable;
@@ -198,7 +254,10 @@ comment on function api.mask_system_attributes (mask api.mask, keys text[]) is
     'Gets the node system attributes of this mask as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.maskitem_attributes (maskitem api.maskitem, keys text[])
+create or replace function api.maskitem_attributes
+    ( maskitem api.maskitem
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_attributes (maskitem.id, keys)
 $$ language sql stable;
@@ -207,7 +266,10 @@ comment on function api.maskitem_attributes (maskitem api.maskitem, keys text[])
     'Gets the node attributes of this mask item as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.maskitem_system_attributes (maskitem api.maskitem, keys text[])
+create or replace function api.maskitem_system_attributes
+    ( maskitem api.maskitem
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_system_attributes (maskitem.id, keys)
 $$ language sql stable;
@@ -216,7 +278,9 @@ comment on function api.maskitem_system_attributes (maskitem api.maskitem, keys 
     'Gets the node system attributes of this mask item as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.metafield_metadatatype (mf api.metafield)
+create or replace function api.metafield_metadatatype
+    ( mf api.metafield
+    )
     returns api.metadatatype as $$
     select * from entity.metadatatype
     where metadatatype.id = mf.metadatatype_id
@@ -226,7 +290,10 @@ comment on function api.metafield_metadatatype (mf api.metafield) is
     'Gets the meta data type associated with this meta field.';
 
 
-create or replace function api.mapping_attributes (mapping api.mapping, keys text[])
+create or replace function api.mapping_attributes
+    ( mapping api.mapping
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_attributes(mapping.id, keys)
 $$ language sql stable;
@@ -235,7 +302,10 @@ comment on function api.mapping_attributes (mapping api.mapping, keys text[]) is
     'Gets the node attributes of this mapping as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.mapping_system_attributes (mapping api.mapping, keys text[])
+create or replace function api.mapping_system_attributes
+    ( mapping api.mapping
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_system_attributes(mapping.id, keys)
 $$ language sql stable;
@@ -244,7 +314,10 @@ comment on function api.mapping_system_attributes (mapping api.mapping, keys tex
     'Gets the node system attributes of this mapping as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.mappingfield_attributes (mappingfield api.mappingfield, keys text[])
+create or replace function api.mappingfield_attributes
+    ( mappingfield api.mappingfield
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_attributes(mappingfield.id, keys)
 $$ language sql stable;
@@ -253,7 +326,10 @@ comment on function api.mappingfield_attributes (mappingfield api.mappingfield, 
     'Gets the node attributes of this mapping field as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.mappingfield_system_attributes (mappingfield api.mappingfield, keys text[])
+create or replace function api.mappingfield_system_attributes
+    ( mappingfield api.mappingfield
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_system_attributes(mappingfield.id, keys)
 $$ language sql stable;
@@ -262,7 +338,11 @@ comment on function api.mappingfield_system_attributes (mappingfield api.mapping
     'Gets the node system attributes of this mapping field as a JSON value, optionally filtered by a list of keys.';
 
 
-create or replace function api.metadatatype_metafields (mdt api.metadatatype, type text, find text)
+create or replace function api.metadatatype_metafields
+    ( mdt api.metadatatype
+    , type text
+    , find text
+    )
     returns setof api.metafield as $$
     select * from entity.metafield
     where metafield.metadatatype_id = mdt.id
@@ -279,7 +359,10 @@ comment on function api.metadatatype_metafields (mdt api.metadatatype, type text
     'Reads and enables pagination through all meta fields of this meta data type, optionally filtered by type, and searchable by name, label and description.';
 
 
-create or replace function api.metadatatype_metafield_by_name (mdt api.metadatatype, name text)
+create or replace function api.metadatatype_metafield_by_name
+    ( mdt api.metadatatype
+    , name text
+    )
     returns api.metafield as $$
     select * from entity.metafield
     where metafield.metadatatype_id = mdt.id
@@ -290,7 +373,9 @@ comment on function api.metadatatype_metafield_by_name (mdt api.metadatatype, na
     'Gets a meta field of this meta data type by name.';
 
 
-create or replace function api.mask_metadatatype (mask api.mask)
+create or replace function api.mask_metadatatype
+    ( mask api.mask
+    )
     returns api.metadatatype as $$
     select * from entity.metadatatype
     where metadatatype.id = mask.metadatatype_id
@@ -300,7 +385,14 @@ comment on function api.mask_metadatatype (mask api.mask) is
     'Gets the meta data type of this mask.';
 
 
-create or replace function api.metadatatype_masks (mdt api.metadatatype, masktype text, language text, is_default boolean, is_vgroup boolean, find text)
+create or replace function api.metadatatype_masks
+    ( mdt api.metadatatype
+    , masktype text
+    , language text
+    , is_default boolean
+    , is_vgroup boolean
+    , find text
+    )
     returns setof api.mask as $$
     select * from entity.mask
     where mask.metadatatype_id = mdt.id
@@ -319,7 +411,10 @@ comment on function api.metadatatype_masks (mdt api.metadatatype, masktype text,
     'Reads and enables pagination through all masks of this meta data type, optionally filtered by type, language, is_default, is_vgroup, and searchable by name and description.';
 
 
-create or replace function api.metadatatype_mask_by_name (mdt api.metadatatype, name text)
+create or replace function api.metadatatype_mask_by_name
+    ( mdt api.metadatatype
+    , name text
+    )
     returns api.mask as $$
     select * from entity.mask
     where mask.metadatatype_id = mdt.id
@@ -330,7 +425,13 @@ comment on function api.metadatatype_mask_by_name (mdt api.metadatatype, name te
     'Gets a mask of this meta data type by name.';
 
 
-create or replace function api.mask_maskitems (mask api.mask, type text, fieldtype text, is_required boolean, find text)
+create or replace function api.mask_maskitems
+    ( mask api.mask
+    , type text
+    , fieldtype text
+    , is_required boolean
+    , find text
+    )
     returns setof api.maskitem as $$
     select * from entity.maskitem
     where maskitem.parent_id = mask.id
@@ -347,7 +448,10 @@ comment on function api.mask_maskitems (mask api.mask, type text, fieldtype text
     'Reads and enables pagination through all items of this mask, optionally filtered by type, fieldtype and is_required, and searchable by name.';
 
 
-create or replace function api.mask_maskitem_by_name (mask api.mask, name text)
+create or replace function api.mask_maskitem_by_name
+    ( mask api.mask
+    , name text
+    )
     returns api.maskitem as $$
     select * from entity.maskitem
     where maskitem.parent_id = mask.id
@@ -358,7 +462,12 @@ comment on function api.mask_maskitem_by_name (mask api.mask, name text) is
     'Gets an item of this mask by name.';
 
 
-create or replace function api.maskitem_subitems (parent api.maskitem, type text, is_required boolean, find text)
+create or replace function api.maskitem_subitems
+    ( parent api.maskitem
+    , type text
+    , is_required boolean
+    , find text
+    )
     returns setof api.maskitem as $$
     select * from entity.maskitem
     where maskitem.parent_id = parent.id
@@ -374,7 +483,10 @@ comment on function api.maskitem_subitems (parent api.maskitem, type text, is_re
     'Reads and enables pagination through all sub-items of this mask item, optionally filtered by type and is_required, and searchable by name.';
 
 
-create or replace function api.maskitem_subitem_by_name (parent api.maskitem, name text)
+create or replace function api.maskitem_subitem_by_name
+    ( parent api.maskitem
+    , name text
+    )
     returns api.maskitem as $$
     select * from entity.maskitem
     where maskitem.parent_id = parent.id
@@ -385,7 +497,9 @@ comment on function api.maskitem_subitem_by_name (parent api.maskitem, name text
     'Gets a sub-item of this mask item by name.';
 
 
-create or replace function api.maskitem_superitem (child api.maskitem)
+create or replace function api.maskitem_superitem
+    ( child api.maskitem
+    )
     returns api.maskitem as $$
     select * from entity.maskitem
     where maskitem.id = child.parent_id
@@ -395,7 +509,9 @@ comment on function api.maskitem_superitem (child api.maskitem) is
     'Gets the super-item of this mask item. Returns null if this item is a direct child of a mask.';
 
 
-create or replace function api.maskitem_mask (child api.maskitem)
+create or replace function api.maskitem_mask
+    (child api.maskitem
+    )
     returns api.mask as $$
     select * from entity.mask
     where mask.id = child.parent_id
@@ -406,7 +522,9 @@ comment on function api.maskitem_mask (api.maskitem) is
 -- We may want a recursive query to get the mask of a nested maskitem too.
 
 
-create or replace function api.maskitem_metafield (maskitem api.maskitem)
+create or replace function api.maskitem_metafield
+    ( maskitem api.maskitem
+    )
     returns api.metafield as $$
     declare result api.metafield;
     begin
@@ -432,7 +550,9 @@ comment on function api.maskitem_metafield (maskitem api.maskitem) is
     'Gets the meta field associated with this mask item.';
 
 
-create or replace function api.maskitem_mappingfield(maskitem api.maskitem)
+create or replace function api.maskitem_mappingfield
+    ( maskitem api.maskitem
+    )
     returns api.mappingfield as $$
     declare result api.mappingfield;
     begin
@@ -452,11 +572,13 @@ create or replace function api.maskitem_mappingfield(maskitem api.maskitem)
     end;
 $$ language plpgsql stable;
 
-comment on function api.maskitem_mappingfield(maskitem api.maskitem) is
+comment on function api.maskitem_mappingfield (maskitem api.maskitem) is
     'Gets the mapping field associated with this mask item. Returns null if there is no such mapping field.';
 
 
-create or replace function api.maskitem_template(maskitem api.maskitem)
+create or replace function api.maskitem_template
+    ( maskitem api.maskitem
+    )
     returns text as $$
     declare result text;
     begin
@@ -473,21 +595,27 @@ create or replace function api.maskitem_template(maskitem api.maskitem)
     end;
 $$ language plpgsql stable;
 
-comment on function api.maskitem_template(maskitem api.maskitem) is
+comment on function api.maskitem_template (maskitem api.maskitem) is
     'Gets the template string of mask item. Returns null if there is no such template.';
 
 
-create or replace function api.mappingfield_mapping(mf api.mappingfield)
+create or replace function api.mappingfield_mapping
+    ( mf api.mappingfield
+    )
     returns api.mapping as $$
     select * from entity.mapping
     where mapping.id = mf.mapping_id
 $$ language sql stable;
 
-comment on function api.mappingfield_mapping(mf api.mappingfield) is
+comment on function api.mappingfield_mapping (mf api.mappingfield) is
     'Gets the mapping of this mapping field.';
 
 
-create or replace function api.mapping_mappingfields(m api.mapping, is_mandatory boolean, find text)
+create or replace function api.mapping_mappingfields
+    ( m api.mapping
+    , is_mandatory boolean
+    , find text
+    )
     returns setof api.mappingfield as $$
     select * from entity.mappingfield
     where mappingfield.mapping_id = m.id
@@ -498,22 +626,27 @@ create or replace function api.mapping_mappingfields(m api.mapping, is_mandatory
           )
 $$ language sql stable rows 80;
 
-comment on function api.mapping_mappingfields(m api.mapping, is_mandatory boolean, find text) is
+comment on function api.mapping_mappingfields (m api.mapping, is_mandatory boolean, find text) is
     'Reads and enables pagination through all mapping fields of this mapping, optionally filtered by is_mandatory, and searchable by name and description.';
 
 
-create or replace function api.mapping_mappingfield_by_name(m api.mapping, name text)
+create or replace function api.mapping_mappingfield_by_name
+    ( m api.mapping
+    , name text
+    )
     returns api.mappingfield as $$
     select * from entity.mappingfield
     where mappingfield.mapping_id = m.id
       and mappingfield.name = mapping_mappingfield_by_name.name
 $$ language sql strict stable;
 
-comment on function api.mapping_mappingfield_by_name(m api.mapping, name text) is
+comment on function api.mapping_mappingfield_by_name (m api.mapping, name text) is
     'Gets a mapping field of this mapping by name.';
 
 
-create or replace function api.mask_exportmapping(mask api.mask)
+create or replace function api.mask_exportmapping
+    (mask api.mask
+    )
     returns api.mapping as $$
     select mapping.*
     from mediatum.node
@@ -521,5 +654,5 @@ create or replace function api.mask_exportmapping(mask api.mask)
     where node.id = mask.id
 $$ language sql stable;
 
-comment on function api.mask_exportmapping(mask api.mask) is
+comment on function api.mask_exportmapping (mask api.mask) is
     'Gets the export mapping of this mask. Returns null if there is no such mapping.';

--- a/backend/src/sql/api-mutation.sql
+++ b/backend/src/sql/api-mutation.sql
@@ -3,7 +3,11 @@
 -- demonstrating mutations
 
 
-create or replace function api.update_document_attribute (id int4, key text, value text)
+create or replace function api.update_document_attribute
+    ( id int4
+    , key text
+    , value text
+    )
     returns api.document as $$
 
     -- Currently we allow updating already existing attributes only.

--- a/backend/src/sql/api-node.sql
+++ b/backend/src/sql/api-node.sql
@@ -3,7 +3,9 @@
 -- for generic access to nodes (that may be folders or documents)
 
 
-create or replace function api.generic_node_by_id (id int4)
+create or replace function api.generic_node_by_id
+    (id int4
+    )
     returns api.generic_node as $$
     select node.id
     from entity.node
@@ -14,7 +16,9 @@ comment on function api.generic_node_by_id (id int4) is
     'Gets a generic node by its mediaTUM node id.';
 
 
-create or replace function api.generic_node_as_document (node api.generic_node)
+create or replace function api.generic_node_as_document
+    ( node api.generic_node
+    )
     returns api.document as $$
     select *
     from entity.document
@@ -25,7 +29,9 @@ comment on function api.generic_node_as_document (node api.generic_node) is
     'Gets the document possibly represented by the generic node';
 
 
-create or replace function api.generic_node_as_folder (node api.generic_node)
+create or replace function api.generic_node_as_folder
+    ( node api.generic_node
+    )
     returns api.folder as $$
     select *
     from entity.folder

--- a/backend/src/sql/debug.sql
+++ b/backend/src/sql/debug.sql
@@ -30,7 +30,9 @@ create or replace function debug.all_nodes (
 $$ language sql stable;
 
 
-create or replace function debug.node_by_id (id int4)
+create or replace function debug.node_by_id
+    ( id int4
+    )
     returns debug.mediatum_node as $$
     select id, type, schema, name, orderpos, fulltext, subnode
     from mediatum.node
@@ -38,13 +40,19 @@ create or replace function debug.node_by_id (id int4)
 $$ language sql strict stable;
 
 
-create or replace function debug.mediatum_node_attributes (node debug.mediatum_node, keys text[])
+create or replace function debug.mediatum_node_attributes
+    ( node debug.mediatum_node
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_attributes (node.id, keys)
 $$ language sql stable;
 
 
-create or replace function debug.mediatum_node_system_attributes (node debug.mediatum_node, keys text[])
+create or replace function debug.mediatum_node_system_attributes
+    ( node debug.mediatum_node
+    , keys text[]
+    )
     returns jsonb as $$
     select aux.get_node_system_attributes (node.id, keys)
 $$ language sql stable;
@@ -119,7 +127,9 @@ $$ language sql stable;
    Maybe we should remove these functions altogether!
    Don't think they are that useful anyway!.
 */
-create or replace function api.metadatatype_node (metadatatype api.metadatatype)
+create or replace function api.metadatatype_node
+    ( metadatatype api.metadatatype
+    )
     returns debug.mediatum_node as $$
     select id, type, schema, name, orderpos, fulltext, subnode
     from mediatum.node
@@ -127,7 +137,9 @@ create or replace function api.metadatatype_node (metadatatype api.metadatatype)
 $$ language sql stable;
 
 
-create or replace function api.metafield_node (metafield api.metafield)
+create or replace function api.metafield_node
+    ( metafield api.metafield
+    )
     returns debug.mediatum_node as $$
     select id, type, schema, name, orderpos, fulltext, subnode
     from mediatum.node
@@ -135,7 +147,9 @@ create or replace function api.metafield_node (metafield api.metafield)
 $$ language sql stable;
 
 
-create or replace function api.mask_node (mask api.mask)
+create or replace function api.mask_node
+    ( mask api.mask
+    )
     returns debug.mediatum_node as $$
     select id, type, schema, name, orderpos, fulltext, subnode
     from mediatum.node
@@ -143,7 +157,9 @@ create or replace function api.mask_node (mask api.mask)
 $$ language sql stable;
 
 
-create or replace function api.maskitem_node (maskitem api.maskitem)
+create or replace function api.maskitem_node
+    ( maskitem api.maskitem
+    )
     returns debug.mediatum_node as $$
     select id, type, schema, name, orderpos, fulltext, subnode
     from mediatum.node
@@ -151,7 +167,9 @@ create or replace function api.maskitem_node (maskitem api.maskitem)
 $$ language sql stable;
 
 
-create or replace function api.mapping_node (mapping api.mapping)
+create or replace function api.mapping_node
+    ( mapping api.mapping
+    )
     returns debug.mediatum_node as $$
     select id, type, schema, name, orderpos, fulltext, subnode
     from mediatum.node
@@ -159,7 +177,9 @@ create or replace function api.mapping_node (mapping api.mapping)
 $$ language sql stable;
 
 
-create or replace function api.mappingfield_node (mappingfield api.mappingfield)
+create or replace function api.mappingfield_node
+    ( mappingfield api.mappingfield
+    )
     returns debug.mediatum_node as $$
     select id, type, schema, name, orderpos, fulltext, subnode
     from mediatum.node
@@ -167,7 +187,9 @@ create or replace function api.mappingfield_node (mappingfield api.mappingfield)
 $$ language sql stable;
 
 
-create or replace function api.document_node (document api.document)
+create or replace function api.document_node
+    ( document api.document
+    )
     returns debug.mediatum_node as $$
     select id, type, schema, name, orderpos, fulltext, subnode
     from mediatum.node
@@ -175,49 +197,63 @@ create or replace function api.document_node (document api.document)
 $$ language sql stable;
 
 
-create or replace function debug.mediatum_node_as_metadatatype (node debug.mediatum_node)
+create or replace function debug.mediatum_node_as_metadatatype
+    ( node debug.mediatum_node
+    )
     returns api.metadatatype as $$
     select * from entity.metadatatype
     where entity.metadatatype.id = node.id
 $$ language sql stable;
 
 
-create or replace function debug.mediatum_node_as_metafield (node debug.mediatum_node)
+create or replace function debug.mediatum_node_as_metafield
+    ( node debug.mediatum_node
+    )
     returns api.metafield as $$
     select * from entity.metafield
     where entity.metafield.id = node.id
 $$ language sql stable;
 
 
-create or replace function debug.mediatum_node_as_mask (node debug.mediatum_node)
+create or replace function debug.mediatum_node_as_mask
+    ( node debug.mediatum_node
+    )
     returns api.mask as $$
     select * from entity.mask
     where entity.mask.id = node.id
 $$ language sql stable;
 
 
-create or replace function debug.mediatum_node_as_maskitem (node debug.mediatum_node)
+create or replace function debug.mediatum_node_as_maskitem
+    ( node debug.mediatum_node
+    )
     returns api.maskitem as $$
     select * from entity.maskitem
     where entity.maskitem.id = node.id
 $$ language sql stable;
 
 
-create or replace function debug.mediatum_node_as_mapping (node debug.mediatum_node)
+create or replace function debug.mediatum_node_as_mapping
+    ( node debug.mediatum_node
+    )
     returns api.mapping as $$
     select * from entity.mapping
     where entity.mapping.id = node.id
 $$ language sql stable;
 
 
-create or replace function debug.mediatum_node_as_mappingfield (node debug.mediatum_node)
+create or replace function debug.mediatum_node_as_mappingfield
+    ( node debug.mediatum_node
+    )
     returns api.mappingfield as $$
     select * from entity.mappingfield
     where entity.mappingfield.id = node.id
 $$ language sql stable;
 
 
-create or replace function debug.mediatum_node_as_document (node debug.mediatum_node)
+create or replace function debug.mediatum_node_as_document
+    ( node debug.mediatum_node
+    )
     returns api.document as $$
     select * from entity.document
     where entity.document.id = node.id

--- a/backend/src/sql/preprocess.sql
+++ b/backend/src/sql/preprocess.sql
@@ -12,7 +12,9 @@ create table preprocess.ufts (
 	tsvec tsvector null
 );
 
-create or replace function preprocess.year_from_attrs (attrs jsonb)
+create or replace function preprocess.year_from_attrs
+    ( attrs jsonb
+    )
     returns int4 as $$
     begin
         return
@@ -25,7 +27,10 @@ create or replace function preprocess.year_from_attrs (attrs jsonb)
     end;
 $$ language plpgsql immutable;
 
-create or replace function preprocess.unified_tsvec_from_attrs_and_fulltext (attrs jsonb, fulltext varchar)
+create or replace function preprocess.unified_tsvec_from_attrs_and_fulltext
+    ( attrs jsonb
+    , fulltext varchar
+    )
     returns tsvector as $$
     declare
         exc_text text;

--- a/backend/src/sql/types.sql
+++ b/backend/src/sql/types.sql
@@ -8,10 +8,10 @@ create schema if not exists api;
 create schema if not exists debug;
 
 
-create type api.generic_node as (
-    id int4
+create type api.generic_node as
+    ( id int4
     -- Add more (hidden) columns?
-);
+    );
 
 comment on type api.generic_node is
     'A generic node, which may be a folder or a document';
@@ -19,14 +19,14 @@ comment on column api.generic_node.id is
     'The mediaTUM node id';
 
 
-create type api.folder as (
-    id int4,
-	parent_id int4,
-    "name" text,
-	orderpos int4,
-	is_collection boolean,
-	num_subfolder integer
-);
+create type api.folder as
+    ( id int4
+	, parent_id int4
+    , "name" text
+	, orderpos int4
+	, is_collection boolean
+	, num_subfolder integer
+    );
 
 comment on type api.folder is
     'A collection or directory, located within a hierarchy';
@@ -44,15 +44,15 @@ comment on column api.folder.num_subfolder is
     'Number of subfolders of this folder';
 
 
-create type api.metadatatype as (
-    id int4,
-    "name" text,
-    longname text,
-    datatypes text,
-    description text,
-    bibtexmapping text,
-    citeprocmapping text
-);
+create type api.metadatatype as
+    ( id int4
+    , "name" text
+    , longname text
+    , datatypes text
+    , description text
+    , bibtexmapping text
+    , citeprocmapping text
+    );
 
 comment on type api.metadatatype is
     'A meta data type';
@@ -72,15 +72,15 @@ comment on column api.metadatatype.citeprocmapping is
     'The citeprocmapping given in the node attributes of the meta data type';
 
 
-create type api.metafield as (
-	id int4,
-	metadatatype_id int4,
-	name text,
-	orderpos int4,
-    description text,
-	label text,
-	"type" text
-);
+create type api.metafield as
+    ( id int4
+	, metadatatype_id int4
+	, name text
+	, orderpos int4
+    , description text
+	, label text
+	, "type" text
+    );
 
 comment on type api.metafield is
     'A field of a meta data type';
@@ -100,18 +100,18 @@ comment on column api.metafield."type" is
     'The type given in the node attributes of the field, e.g. "text", "list" etc';
 
 
-create type api.mask as (
-	id int4,
-	metadatatype_id int4,
-	name text,
-	orderpos int4,
-	masktype text,
-    language text,
-    description text,
-    is_default boolean,
+create type api.mask as
+    ( id int4
+	, metadatatype_id int4
+	, name text
+	, orderpos int4
+	, masktype text
+    , language text
+    , description text
+    , is_default boolean
     -- TODO: Poss. use extra entity mask(item)type
-	is_vgroup boolean
-);
+	, is_vgroup boolean
+    );
 
 comment on type api.mask is
     'A mask used for a specific meta data type';
@@ -135,16 +135,16 @@ comment on column api.mask.is_vgroup is
     'The mask may be a vertical group; given in the node attributes of the mask';
     
 
-create type api.maskitem as (
-	id int4,
-	parent_id int4,
-	name text,
-	orderpos int4,
-	"type" text,
-	fieldtype text,
-    width int4,
-    is_required boolean
-);
+create type api.maskitem as
+    ( id int4
+	, parent_id int4
+	, name text
+	, orderpos int4
+	, "type" text
+	, fieldtype text
+    , width int4
+    , is_required boolean
+    );
 
 comment on type api.maskitem is
     'An item of a specific mask or a sub-item of another mask item';
@@ -164,19 +164,19 @@ comment on column api.maskitem.is_required is
     'The item may be required; as given in the node attributes of the item';
 
     
-create type api.maskitem_reachable as (
-	id int4,
-	mask_id int4,
-	metadatatype_id int4,
-	superitem_id int4,
-	depth integer,
-	name text,
-	orderpos int4,
-	"type" text,
-	fieldtype text,
-    width int4,
-    is_required boolean
-);
+create type api.maskitem_reachable as
+    ( id int4
+	, mask_id int4
+	, metadatatype_id int4
+	, superitem_id int4
+	, depth integer
+	, name text
+	, orderpos int4
+	, "type" text
+	, fieldtype text
+    , width int4
+    , is_required boolean
+    );
 
 comment on type api.maskitem_reachable is
     'An item of a specific mask or a sub-item of another mask item; this uses an alternative implementation to "maskitem", using recursion';
@@ -202,13 +202,13 @@ comment on column api.maskitem_reachable.is_required is
     'The item may be required; as given in the node attributes of the item';
 
     
-create type api.mapping as (
-	id int4,
-	name text,
-	orderpos int4,
-	"type" text,
-    description text
-);
+create type api.mapping as
+    ( id int4
+	, name text
+	, orderpos int4
+	, "type" text
+    , description text
+    );
 
 comment on type api.mapping is
     'A mapping used e.g. for exporting the data selected by a mask';
@@ -224,14 +224,14 @@ comment on column api.mapping.description is
     'A description as given in the node attributes of the mapping';
     
 
-create type api.mappingfield as (
-	id int4,
-	mapping_id int4,
-	name text,
-	orderpos int4,
-    description text,
-    is_mandatory boolean
-);
+create type api.mappingfield as
+    ( id int4
+	, mapping_id int4
+	, name text
+	, orderpos int4
+    , description text
+    , is_mandatory boolean
+    );
 
 comment on type api.mappingfield is
     'A field within a mapping used e.g. for exporting the data selected by a mask';
@@ -247,14 +247,14 @@ comment on column api.mappingfield.is_mandatory is
     'The field may be mandatory; as given in the node attributes of the mapping field';
 
     
-create type api.document as (
-	id int4,
-	"type" text,
-	"schema" text,
-	name text,
-	orderpos int4,
-    attrs jsonb
-);
+create type api.document as
+    ( id int4
+    , "type" text
+    , "schema" text
+    , name text
+    , orderpos int4
+    , attrs jsonb
+    );
 
 comment on type api.document is
     'A document as the basic subject of publication of the media server';
@@ -272,21 +272,22 @@ comment on column api.document.attrs is
     '@omit';
 
 
-create type api.fts_sorting as enum (
-    'by_rank', 'by_date'
-);
+create type api.fts_sorting as enum
+    ( 'by_rank'
+    , 'by_date'
+    );
 
 
 create type api.attribute_test_operator as enum (
     'equality', 'equalitywithblanknull', 'ilike', 'simplefts', 'daterange'
 );
 
-create type api.attribute_test as (
-    key text,
-    operator api.attribute_test_operator,
-    value text,
-    extra text
-);
+create type api.attribute_test as
+    ( key text
+    , operator api.attribute_test_operator
+    , value text
+    , extra text
+    );
 
 comment on type api.attribute_test is
     'Specification for testing  a single attribute value of a document';
@@ -301,13 +302,13 @@ comment on column api.attribute_test.extra is
     'Second comparison value, used if operator may take two values, like "ilike" or "daterange"';
 
 
-create type api.document_result as (
-    number integer,
-    distance float4,
-    recency int4,
-    year int4,
-    document api.document
-);
+create type api.document_result as
+    ( number integer
+    , distance float4
+    , recency int4
+    , year int4
+    , document api.document
+    );
 
 comment on type api.document_result is
     'A single result from a full text search, containing a document';
@@ -324,11 +325,11 @@ comment on column api.document_result.document is
     'The resulting document';
 
 
-create type api.document_result_page as (
-    "offset" integer,
-    has_next_page boolean,
-    content api.document_result[]
-);
+create type api.document_result_page as
+    ( "offset" integer
+    , has_next_page boolean
+    , content api.document_result[]
+    );
 
 comment on type api.document_result_page is
     'A result page from a full text search of documents';
@@ -338,20 +339,20 @@ comment on column api.document_result_page.content is
     'A list of document results from a full text search';
 
 
-create type api.folder_count as (
-    folder_id int4,
-    count integer
-);
+create type api.folder_count as
+    ( folder_id int4
+    , count integer
+    );
 
 comment on type api.folder_count is
     'Specification of the number of documents of a given set within a folder';
 
 
-create type api.docset as (
-    folder_id int4,
-    folder_count api.folder_count,
-    id_list int4[]
-);
+create type api.docset as
+    ( folder_id int4
+    , folder_count api.folder_count
+    , id_list int4[]
+    );
 
 comment on type api.docset is
     'A set of documents as the result of e.g. a FTS query. '
@@ -367,10 +368,10 @@ comment on column api.docset.id_list is
     'it is more of a interim result to be consumed by a counting function.';
 
 
-create type api.facet_value as (
-    value text,
-    count integer
-);
+create type api.facet_value as
+    ( value text
+    , count integer
+    );
 
 comment on type api.facet_value is
     'A facet instance, i.e. the occurences of an attribute''s value.';
@@ -380,12 +381,12 @@ comment on column api.facet_value.count is
     'The number of occurences of the facet.';
 
 
-create type debug.mediatum_node as (
-	id int4,
-	"type" varchar,
-	"schema" varchar,
-	"name" varchar,
-	orderpos int4,
-	fulltext varchar,
-	subnode boolean
-);
+create type debug.mediatum_node as
+    ( id int4
+	, "type" varchar
+	, "schema" varchar
+	, "name" varchar
+	, orderpos int4
+	, fulltext varchar
+	, subnode boolean
+    );


### PR DESCRIPTION
We use this schema for formatting parameter lists of functions:

```plpgsql
create or replace function api.document_values_by_mask
    ( document api.document
    , mask_name text
    )
```
