### PR TITLE
Improve determining needs from route

### DIFF
--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -544,7 +544,11 @@ update msg cache =
             )
 
 
-updateWithDocumentAndResidence : DocumentIdFromSearch -> Maybe ( Document, Maybe Residence ) -> Cache -> ( Cache, Cmd Msg )
+updateWithDocumentAndResidence :
+    DocumentIdFromSearch
+    -> Maybe ( Document, Maybe Residence )
+    -> Cache
+    -> ( Cache, Cmd Msg )
 updateWithDocumentAndResidence documentIdFromSearch maybeDocumentAndResidence cache =
     let
         cache1 =
@@ -557,6 +561,9 @@ updateWithDocumentAndResidence documentIdFromSearch maybeDocumentAndResidence ca
                                 (Success (Just document))
                                 cache.documents
                     }
+                        |> insertNodeType
+                            (Id.asNodeId documentIdFromSearch.id)
+                            NodeIsDocument
 
                 Nothing ->
                     { cache
@@ -566,6 +573,9 @@ updateWithDocumentAndResidence documentIdFromSearch maybeDocumentAndResidence ca
                                 (Success Nothing)
                                 cache.documents
                     }
+                        |> insertNodeType
+                            (Id.asNodeId documentIdFromSearch.id)
+                            NodeIsNeither
 
         cache2 =
             case maybeDocumentAndResidence of

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -105,7 +105,7 @@ type alias Cache =
     , folders : Sort.Dict.Dict FolderId (ApiData Folder)
     , subfolderIds : Sort.Dict.Dict FolderId (ApiData (List FolderId))
     , nodeTypes : Sort.Dict.Dict NodeId (ApiData NodeType)
-    , documents : Sort.Dict.Dict DocumentIdFromSearch (ApiData (Maybe Document))
+    , documents : Sort.Dict.Dict DocumentIdFromSearch (ApiData Document)
     , residence : Sort.Dict.Dict DocumentId (ApiData Residence)
     , documentsPages : Sort.Dict.Dict ( Selection, Window ) (ApiData DocumentsPage)
     , folderCounts : Sort.Dict.Dict Selection (ApiData FolderCounts)
@@ -384,7 +384,7 @@ updateWithModifiedDocument document cache =
         | documents =
             Sort.Dict.insert
                 (DocumentIdFromSearch document.id Nothing)
-                (Success (Just document))
+                (Success document)
                 cache.documents
     }
 
@@ -558,7 +558,7 @@ updateWithDocumentAndResidence documentIdFromSearch maybeDocumentAndResidence ca
                         | documents =
                             Sort.Dict.insert
                                 documentIdFromSearch
-                                (Success (Just document))
+                                (Success document)
                                 cache.documents
                     }
                         |> insertNodeType
@@ -566,13 +566,7 @@ updateWithDocumentAndResidence documentIdFromSearch maybeDocumentAndResidence ca
                             NodeIsDocument
 
                 Nothing ->
-                    { cache
-                        | documents =
-                            Sort.Dict.insert
-                                documentIdFromSearch
-                                (Success Nothing)
-                                cache.documents
-                    }
+                    cache
                         |> insertNodeType
                             (Id.asNodeId documentIdFromSearch.id)
                             NodeIsNeither

--- a/frontend/src/elm/Types/Id.elm
+++ b/frontend/src/elm/Types/Id.elm
@@ -9,6 +9,7 @@ module Types.Id exposing
     , toInt
     , fromInt
     , toString
+    , isValidId
     , ordering
     )
 
@@ -43,6 +44,7 @@ module Types.Id exposing
 
 # Miscellaneous
 
+@docs isValidId
 @docs ordering
 
 -}
@@ -121,6 +123,21 @@ dummyValueToAvoidElmAnalyseErrors =
     , EmptyTypeConstructor_Node
     , EmptyTypeConstructor_Document
     )
+
+
+maxValidId : Int
+maxValidId =
+    2 ^ 31 - 1
+
+
+{-| Checks if the id is in the allowed range (0 .. 2^31-1).
+
+Note that the server represents ids as (signed) int4 in PostgreSQL.
+
+-}
+isValidId : Id a -> Bool
+isValidId (Id i) =
+    i >= 0 && i <= maxValidId
 
 
 {-| Convert any id type into a `NodeId`.

--- a/frontend/src/elm/Types/Presentation.elm
+++ b/frontend/src/elm/Types/Presentation.elm
@@ -42,7 +42,7 @@ import Types.Selection exposing (SelectMethod(..), Selection)
 
 {-| -}
 type Presentation
-    = GenericPresentation (Maybe ( NodeId, Maybe NodeId ))
+    = GenericPresentation (Maybe ( NodeId, Maybe DocumentIdFromSearch ))
     | CollectionPresentation FolderId
     | DocumentPresentation (Maybe FolderId) DocumentIdFromSearch
     | ListingPresentation Selection Window
@@ -160,4 +160,13 @@ fromRoute cache route =
                         )
 
                 _ ->
-                    GenericPresentation (Just ( nodeIdOne, Just nodeIdTwo ))
+                    GenericPresentation
+                        (Just
+                            ( nodeIdOne
+                            , Just
+                                (DocumentIdFromSearch
+                                    (nodeIdTwo |> Id.asDocumentId)
+                                    route.parameters.ftsTerm
+                                )
+                            )
+                        )

--- a/frontend/src/elm/UI/Article.elm
+++ b/frontend/src/elm/UI/Article.elm
@@ -102,15 +102,20 @@ initialModel presentation =
 needs : List String -> Presentation -> Cache.Needs
 needs facetKeys presentation =
     case presentation of
-        GenericPresentation maybeNodeIds ->
-            case maybeNodeIds of
+        GenericPresentation genericParameters ->
+            case genericParameters of
                 Nothing ->
                     Types.Needs.none
 
-                Just ( nodeIdOne, maybeNodeIdTwo ) ->
-                    [ nodeIdOne ]
-                        |> Maybe.Extra.cons maybeNodeIdTwo
-                        |> List.map Cache.NeedGenericNode
+                Just ( nodeIdOne, maybeDocumentIdFromSearch ) ->
+                    let
+                        maybeNeedTwo =
+                            maybeDocumentIdFromSearch
+                                |> Maybe.map
+                                    Cache.NeedDocumentFromSearch
+                    in
+                    [ Cache.NeedGenericNode nodeIdOne ]
+                        |> Maybe.Extra.cons maybeNeedTwo
                         |> List.map Types.Needs.atomic
                         |> Types.Needs.batch
 
@@ -250,10 +255,10 @@ viewBreadcrumbs context maybeFolderId =
 viewContent : Context -> Model -> Html Msg
 viewContent context model =
     case ( model.content, context.presentation ) of
-        ( GenericModel subModel, GenericPresentation nodeIds ) ->
+        ( GenericModel subModel, GenericPresentation genericParameters ) ->
             UI.Article.Generic.view
                 { cache = context.cache
-                , nodeIds = nodeIds
+                , genericParameters = genericParameters
                 }
                 subModel
                 |> Html.map GenericMsg

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -145,7 +145,7 @@ initEditAttributeValue context model =
             context.cache.documents
             context.documentIdFromSearch
     of
-        RemoteData.Success (Just document) ->
+        RemoteData.Success document ->
             let
                 ( key1, value1 ) =
                     case Document.attributeValue model.editAttributeKey document of
@@ -191,15 +191,8 @@ view context model =
             RemoteData.Failure error ->
                 Utils.Html.viewApiError error
 
-            RemoteData.Success ( Just document, residence ) ->
+            RemoteData.Success ( document, residence ) ->
                 viewDocument context model document residence
-
-            RemoteData.Success ( Nothing, _ ) ->
-                Html.span []
-                    [ Html.text "Document with id "
-                    , Html.text (context.documentIdFromSearch.id |> Id.toString)
-                    , Html.text " not available"
-                    ]
         ]
 
 

--- a/frontend/src/elm/UI/Article/Generic.elm
+++ b/frontend/src/elm/UI/Article/Generic.elm
@@ -22,7 +22,7 @@ import Cache exposing (Cache)
 import Cache.Derive
 import Html exposing (Html)
 import RemoteData exposing (RemoteData(..))
-import Types exposing (NodeType(..))
+import Types exposing (DocumentIdFromSearch, NodeType(..))
 import Types.Id as Id exposing (NodeId)
 import UI.Icons
 import Utils
@@ -32,7 +32,7 @@ import Utils.Html
 {-| -}
 type alias Context =
     { cache : Cache
-    , nodeIds : Maybe ( NodeId, Maybe NodeId )
+    , genericParameters : Maybe ( NodeId, Maybe DocumentIdFromSearch )
     }
 
 
@@ -64,7 +64,7 @@ view context model =
     let
         remoteDataMessage =
             -- Find the reason why we have a GenericPresentation
-            case context.nodeIds of
+            case context.genericParameters of
                 Nothing ->
                     Cache.Derive.getRootFolder context.cache
                         |> RemoteData.map (always "Going to show the root folder")
@@ -90,7 +90,11 @@ view context model =
                                     ++ Id.toString nodeId
                             )
 
-                Just ( nodeIdOne, Just nodeIdTwo ) ->
+                Just ( nodeIdOne, Just documentIdFromSearch ) ->
+                    let
+                        nodeIdTwo =
+                            Id.asNodeId documentIdFromSearch.id
+                    in
                     RemoteData.map2 Tuple.pair
                         (Cache.Derive.getNodeType context.cache nodeIdOne |> Cache.Derive.asDerivedData)
                         (Cache.Derive.getNodeType context.cache nodeIdTwo |> Cache.Derive.asDerivedData)

--- a/frontend/src/elm/Utils.elm
+++ b/frontend/src/elm/Utils.elm
@@ -1,5 +1,6 @@
 module Utils exposing
     ( ifElse
+    , ensure
     , when
     , tupleAddThird
     , tupleRemoveThird
@@ -21,6 +22,7 @@ module Utils exposing
 # Bool
 
 @docs ifElse
+@docs ensure
 @docs when
 
 
@@ -75,6 +77,17 @@ ifElse ifTrue ifFalse bool =
 
     else
         ifFalse
+
+
+{-| Lift value into Maybe depending on a predicate
+-}
+ensure : (a -> Bool) -> a -> Maybe a
+ensure predicate value =
+    if predicate value then
+        Just value
+
+    else
+        Nothing
 
 
 {-| Conditionally apply a function


### PR DESCRIPTION
- Check that node ids from URLs are valid on the API 
- Cache documents without wrapping them in Maybe
- Avoid fetching a document twice (first as a generic node and secondly as a document with a search highlight).