### PR TITLE
Preprocessed Aspect Table

### DIFF
--- a/backend/src/sql/api-facets.sql
+++ b/backend/src/sql/api-facets.sql
@@ -236,6 +236,35 @@ comment on function api.docset_facet_by_mask
 ;
 
 
+create or replace function api.docset_facet_by_apect
+    ( docset api.docset
+    , aspect_name text
+    )
+    returns setof api.facet_value as $$
+        select
+            value,
+            count(value)::integer
+        from 
+            preprocess.aspect,
+            unnest (aspect.values) as value
+        where aspect.nid = ANY (docset.id_list)
+          and aspect.name = aspect_name
+        group by value
+        order by count(value) desc, value
+        ;
+$$ language sql strict stable parallel safe rows 50;
+
+comment on function api.docset_facet_by_apect
+    ( docset api.docset
+    , aspect_name text
+    ) is
+    'Gather the most frequent values of a facet within the docset. '
+    'The facet in question is specified by an aspectName. '
+    -- TODO: Determine how we will handle missing values; and describe it here in this doc.
+    'Documents without the corresponding key indicate the value as the empty string.'
+;
+
+
 create or replace function api.all_documents_facet_by_key
     ( folder_id int4
     , key text

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -81,8 +81,15 @@ $$ language sql;
 
 create or replace function preprocess.add_document_aspects (document mediatum.node)
     returns void as $$
+        call preprocess.add_document_aspect(document, 'type', array['type'], false);
+        call preprocess.add_document_aspect(document, 'origin', array['origin'], false);
+        call preprocess.add_document_aspect(document, 'subject', array['subject'], false);
+        call preprocess.add_document_aspect(document, 'subject2', array['subject2'], true);
         call preprocess.add_document_aspect(document, 'title', array['title', 'title-translated'], false);
-        call preprocess.add_document_aspect(document, 'person', array['author', 'advisor', 'referee'], true);
+        call preprocess.add_document_aspect(document, 'author', array['author', 'author.fullname_comma'], true);
+        call preprocess.add_document_aspect(document, 'person', array['author', 'author.fullname_comma', 'advisor', 'referee'], true);
+        call preprocess.add_document_aspect(document, 'keywords', array['keywords', 'keywords-translated'], true);
+        call preprocess.add_document_aspect(document, 'description', array['description', 'description-translated'], false);
 $$ language sql volatile;
 
 

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -34,13 +34,15 @@ create table preprocess.aspect (
 create or replace function preprocess.prepare_values (values_array text[])
     -- 1. Eliminate duplicate values with stable sort order
     --    (cf https://dba.stackexchange.com/a/211502).
-    -- 2. If there are no values, return an array containing the empty string
+    -- 2. Remove null values (which come from empty attrs values)
+    -- 3. If there are no values, return an array containing the empty string
     --    (which denotes the special value "not specified").
     returns text[] as $$
     select coalesce (array_agg(element order by index), array[''])
     from (
         select distinct on (element) element,index
         from unnest(values_array) with ordinality as p(element,index)
+        where element is not null
         order by element,index
     ) sub
 $$ language sql immutable strict;

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -98,9 +98,9 @@ create or replace function preprocess.some_attributes_as_tsvector (attrs jsonb, 
 $$ language sql immutable strict;
 
 
-drop view if exists preprocess.aspectview;
+drop view if exists preprocess.aspect_view;
 
-create view preprocess.aspectview as
+create view preprocess.aspect_view as
     select
         document.id as nid,
         aspect_def.name as name,
@@ -122,7 +122,7 @@ set session client_min_messages to warning;
 
 insert into preprocess.aspect (nid, name, values, tsvec)
     select nid, name, values, tsvec
-    from preprocess.aspectview
+    from preprocess.aspect_view
     -- where nid > 601000 and nid < 602000 -- For testing: process some well-known documents only
     -- limit 44000 -- For testing: process only a smaller number of rows
 ;

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -96,7 +96,7 @@ create or replace function preprocess.add_document_aspects (document mediatum.no
     returns void as $$
         call preprocess.add_document_aspect(document, 'type', array['type'], false);
         call preprocess.add_document_aspect(document, 'origin', array['origin'], false);
-        call preprocess.add_document_aspect(document, 'subject', array['subject'], false);
+        call preprocess.add_document_aspect(document, 'subject', array['subject'], true);
         call preprocess.add_document_aspect(document, 'subject2', array['subject2'], true);
         call preprocess.add_document_aspect(document, 'title', array['title', 'title-translated'], false);
         call preprocess.add_document_aspect(document, 'author', array['author', 'author.fullname_comma'], true);

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -16,21 +16,21 @@ create or replace function preprocess.some_attributes_as_array (attrs jsonb, key
 	select array(
         select left(value, 1048000) from jsonb_each_text(attrs) where key = any (keys)
     )
-$$ language sql stable;
+$$ language sql immutable;
 
 
 create or replace function preprocess.some_attributes_as_text (attrs jsonb, keys text[])
     returns text as $$
 	select
         array_to_string(preprocess.some_attributes_as_array(attrs, keys), ' ')
-$$ language sql stable;
+$$ language sql immutable;
 
 
 create or replace function preprocess.some_attributes_as_tsvector (attrs jsonb, keys text[])
     returns tsvector as $$
 	select
         to_tsvector('english_german', preprocess.some_attributes_as_text(attrs, keys))
-$$ language sql stable;
+$$ language sql immutable;
 
 
 create or replace procedure preprocess.add_document_aspect (document mediatum.node, name text, keys text[])

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -23,10 +23,11 @@ insert into preprocess.aspect_def values
 
 drop table if exists preprocess.aspect cascade;
 create table preprocess.aspect (
-	nid int4,
+	nid int4 references mediatum.node(id) on delete cascade,
     name text,
-    values text[],
-	tsvec tsvector null
+    values text[] not null,
+	tsvec tsvector not null,
+    primary key (nid, name)
 );
 
 
@@ -121,11 +122,6 @@ insert into preprocess.aspect (nid, name, values, tsvec)
 set session client_min_messages to notice;
 
 ------------------------------------
-
-alter table preprocess.aspect
-    add constraint aspect_pkey primary key (nid, name),
-    add constraint aspect_nid_fkey foreign key (nid) references node(id) on delete cascade
-;
 
 create index if not exists aspect_rum_tsvector_ops
     on preprocess.aspect

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -46,11 +46,20 @@ $$ language sql immutable strict;
 create or replace function preprocess.normalize_value (value text, normalize_year boolean)
     returns text as $$
     select
-        case when normalize_year then
-            (substring(left(value, 1048000) from '\d{4}'))
-        else
-            left(value, 1048000)
-        end
+        left (
+            substring(
+                substring (value,
+                    case when normalize_year then
+                        '\d{4}'
+                    else
+                        '.*'
+                    end
+                )
+                , '(\S.*\S)'
+            )
+            , 1048000
+        )
+        
 $$ language sql immutable strict;
 
 

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -99,7 +99,8 @@ create or replace procedure preprocess.populate_aspect_table ()
             from mediatum.node
             where node.schema is not null
                 and not aux.nodetype_is_container (node.type)
-        limit 10000 -- For testing the code we may just process a small fraction of the data
+                -- and node.id > 601000 and node.id < 602000 -- For testing: process some well-known documents only
+        -- limit 5000 -- For testing: just process a small fraction of the data
         ;
 $$ language sql;
 

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -143,4 +143,7 @@ create index if not exists aspect_rum_tsvector_addon_ops
   with (attach ='name', to = 'tsvec')
  ;
 
+-- TODO: Create index on (name, values), using gin utilizing extension btree_gin
+--       See https://stackoverflow.com/q/31945601
+
 analyze preprocess.aspect;

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -111,9 +111,14 @@ create view preprocess.aspect_view as
         aspect_def.name as name,
         preprocess.some_attributes_as_array(document.attrs, aspect_def.keys, aspect_def.split_at_semicolon, aspect_def.normalize_year) as values,
         preprocess.some_attributes_as_tsvector(document.attrs, aspect_def.keys, aspect_def.split_at_semicolon, aspect_def.normalize_year) as tsvec
-    from mediatum.node as document, preprocess.aspect_def
-    where document.schema is not null
-        and not aux.nodetype_is_container (document.type)
+    from
+        mediatum.node as document,
+        mediatum.nodetype,
+        preprocess.aspect_def
+    where
+        document.schema is not null
+        and document.type = nodetype.name
+        and not nodetype.is_container
 ;
 
 

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -1,0 +1,83 @@
+
+
+drop table if exists preprocess.aspect;  
+
+create table preprocess.aspect (
+	nid serial references mediatum.node(id) on delete cascade,
+    name text,
+    values text[],
+	tsvec tsvector null,
+    primary key (nid, name)
+);
+
+
+create or replace function preprocess.some_attributes_as_array (attrs jsonb, keys text[])
+    returns text[] as $$
+	select array(
+        select left(value, 1048000) from jsonb_each_text(attrs) where key = any (keys)
+    )
+$$ language sql stable;
+
+
+create or replace function preprocess.some_attributes_as_text (attrs jsonb, keys text[])
+    returns text as $$
+	select
+        array_to_string(preprocess.some_attributes_as_array(attrs, keys), ' ')
+$$ language sql stable;
+
+
+create or replace function preprocess.some_attributes_as_tsvector (attrs jsonb, keys text[])
+    returns tsvector as $$
+	select
+        to_tsvector('english_german', preprocess.some_attributes_as_text(attrs, keys))
+$$ language sql stable;
+
+
+create or replace procedure preprocess.add_document_aspect (document mediatum.node, name text, keys text[])
+    as $$
+        insert into preprocess.aspect (nid, name, values, tsvec)
+            select
+                document.id,
+                name,
+                preprocess.some_attributes_as_array(document.attrs, keys) as values,
+                preprocess.some_attributes_as_tsvector(document.attrs, keys) as tsvec
+        ;
+$$ language sql;
+
+create or replace function preprocess.add_document_aspects (document mediatum.node)
+    returns void as $$
+        call preprocess.add_document_aspect(document, 'title', array['title', 'title-translated']);
+$$ language sql volatile;
+
+
+create or replace procedure preprocess.populate_aspect_table ()
+    as $$
+        select preprocess.add_document_aspects(node::mediatum.node)
+            from mediatum.node
+            where node.schema is not null
+                and not aux.nodetype_is_container (node.type)
+        limit 1000 -- For testing the code we may just process a small fraction of the data
+        ;
+$$ language sql;
+
+
+-- Suppress notices about "Word is too long to be indexed. Words longer than 2047 characters are ignored."
+-- We don't mind that such long lexemes don't get indexed.
+set session client_min_messages to warning;
+
+delete from preprocess.aspect;   
+call preprocess.populate_aspect_table ();
+
+-- Reset message level to default
+set session client_min_messages to notice;
+
+create index if not exists aspect_rum_tsvector_ops
+    on preprocess.aspect
+ using rum (tsvec rum_tsvector_ops)
+;
+
+create index if not exists aspect_rum_tsvector_addon_ops
+    on preprocess.aspect
+ using rum (tsvec rum_tsvector_addon_ops, name)
+  with (attach ='name', to = 'tsvec')
+ ;

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -17,7 +17,7 @@ insert into preprocess.aspect_def values
     ('person', array['author', 'author-contrib', 'author.fullname_comma', 'advisor', 'referee'], true, false),
     ('keywords', array['keywords', 'keywords-translated'], true, false),
     ('description', array['description', 'description-translated'], false, false),
-    ('year', array['year'], false, true)
+    ('year', array['year', 'year-accepted'], false, true)
 ;
 
 

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -3,7 +3,7 @@
 drop table if exists preprocess.aspect;  
 
 create table preprocess.aspect (
-	nid serial references mediatum.node(id) on delete cascade,
+	nid int4 references mediatum.node(id) on delete cascade,
     name text,
     values text[],
 	tsvec tsvector null,

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -30,7 +30,7 @@ create or replace function preprocess.array_unique_stable (input_array anyarray)
 $$ language sql immutable strict;
 
 
-create or replace function preprocess.some_attributes_as_array (attrs jsonb, keys text[], split_at_semicolon boolean default false)
+create or replace function preprocess.some_attributes_as_array (attrs jsonb, keys text[], split_at_semicolon boolean)
     returns text[] as $$
     select preprocess.array_unique_stable(
         case when split_at_semicolon then
@@ -50,25 +50,25 @@ create or replace function preprocess.some_attributes_as_array (attrs jsonb, key
             )
         end
     )
-$$ language sql immutable;
+$$ language sql immutable strict;
 
 
 
-create or replace function preprocess.some_attributes_as_text (attrs jsonb, keys text[], split_at_semicolon boolean default false)
+create or replace function preprocess.some_attributes_as_text (attrs jsonb, keys text[], split_at_semicolon boolean)
     returns text as $$
 	select
         array_to_string(preprocess.some_attributes_as_array(attrs, keys, split_at_semicolon), ' ')
-$$ language sql immutable;
+$$ language sql immutable strict;
 
 
-create or replace function preprocess.some_attributes_as_tsvector (attrs jsonb, keys text[], split_at_semicolon boolean default false)
+create or replace function preprocess.some_attributes_as_tsvector (attrs jsonb, keys text[], split_at_semicolon boolean)
     returns tsvector as $$
 	select
         to_tsvector('english_german', preprocess.some_attributes_as_text(attrs, keys, split_at_semicolon))
-$$ language sql immutable;
+$$ language sql immutable strict;
 
 
-create or replace procedure preprocess.add_document_aspect (document mediatum.node, name text, keys text[], split_at_semicolon boolean default false)
+create or replace procedure preprocess.add_document_aspect (document mediatum.node, name text, keys text[], split_at_semicolon boolean)
     as $$
         insert into preprocess.aspect (nid, name, values, tsvec)
             select

--- a/backend/src/sql/preprocess-aspect.sql
+++ b/backend/src/sql/preprocess-aspect.sql
@@ -12,9 +12,9 @@ insert into preprocess.aspect_def values
     ('origin', array['origin'], false, false),
     ('subject', array['subject'], true, false),
     ('subject2', array['subject2'], true, false),
-    ('title', array['title', 'title-translated'], false, false),
-    ('author', array['author', 'author.fullname_comma'], true, false),
-    ('person', array['author', 'author.fullname_comma', 'advisor', 'referee'], true, false),
+    ('title', array['title', 'title-translated', 'title-contrib'], false, false),
+    ('author', array['author', 'author-contrib', 'author.fullname_comma'], true, false),
+    ('person', array['author', 'author-contrib', 'author.fullname_comma', 'advisor', 'referee'], true, false),
     ('keywords', array['keywords', 'keywords-translated'], true, false),
     ('description', array['description', 'description-translated'], false, false),
     ('year', array['year'], false, true)

--- a/backend/src/sql/preprocess-mfts.sql
+++ b/backend/src/sql/preprocess-mfts.sql
@@ -1,0 +1,59 @@
+
+
+drop table if exists preprocess.mfts;  
+
+create table preprocess.mfts (
+	nid serial references mediatum.node(id) on delete cascade,
+    key text,
+    value text,
+    value_normalized text,
+	tsvec tsvector null,
+    primary key (nid, key)
+);
+
+drop view if exists preprocess.mfts_as_view;
+
+create view preprocess.mfts_as_view as
+    select
+        node.id as nid,
+        attr.key as key,
+        attr.value as value,
+        aux.normalize_facet_value(attr.value) as value_normalized,
+        to_tsvector('english_german', left(attr.value, 1048000)) as tsvec
+    from
+        mediatum.node,
+        jsonb_each_text(node.attrs) as attr
+    where 
+        -- TODO: Is this the best way to identify documents?
+        -- TODO: Apply also in ufts preprocessing
+        -- TODO: Check handling of emtpy and null values
+        node.schema is not null
+        and not aux.nodetype_is_container (node.type)
+;
+
+delete from preprocess.mfts;   
+
+-- Suppress notices about "Word is too long to be indexed. Words longer than 2047 characters are ignored."
+-- We don't mind that such long lexemes don't get indexed.
+set session client_min_messages to warning;
+
+insert into preprocess.mfts (nid, key, value, value_normalized, tsvec)
+  select * 
+  from preprocess.mfts_as_view
+  -- limit 200000 -- For testing the code one may just process a small fraction of the data
+;
+
+-- Reset message level to default
+set session client_min_messages to notice;
+
+create index if not exists mfts_rum_tsvector_ops
+    on preprocess.mfts
+ using rum (tsvec rum_tsvector_ops)
+;
+
+create index if not exists mfts_rum_tsvector_addon_ops
+    on preprocess.mfts
+ using rum (tsvec rum_tsvector_addon_ops, key)
+  with (attach ='key', to = 'tsvec')
+ ;
+

--- a/backend/src/sql/preprocess-mfts.sql
+++ b/backend/src/sql/preprocess-mfts.sql
@@ -3,7 +3,7 @@
 drop table if exists preprocess.mfts;  
 
 create table preprocess.mfts (
-	nid serial references mediatum.node(id) on delete cascade,
+	nid int4 references mediatum.node(id) on delete cascade,
     key text,
     value text,
     value_normalized text,

--- a/backend/src/sql/preprocess.sql
+++ b/backend/src/sql/preprocess.sql
@@ -6,7 +6,7 @@ create schema if not exists preprocess;
 
 
 create table preprocess.ufts (
-	nid serial not null primary key references mediatum.node(id) on delete cascade,
+	nid int4 primary key references mediatum.node(id) on delete cascade,
 	"year" int4 null,
 	recency int4 null,
 	tsvec tsvector null

--- a/backend/src/sql/preprocess.sql
+++ b/backend/src/sql/preprocess.sql
@@ -93,6 +93,8 @@ create index if not exists ufts_rum_tsvector_addon_ops
   with (attach ='recency', to = 'tsvec');
 
 
+analyze preprocess.ufts;
+
 ------------------------------------------------------------------
 
 -- Possible index on table noderelation


### PR DESCRIPTION
## Objectives

- Definition of _attributes of interest_ for search terms and for faceted search.
- Preprocessing of certain attribute storage formats.
- Speep up of filtering and facets handling queries.

## The notion of _aspect_

- An aspect comprises one or more attributes of a document. Example: Aspect `person` may include the attributes `author`, `author-contrib`, `author.fullname_comma`, `advisor` and `referee`.
- For some aspects the corresponding attribute values may be split into several aspect values. Example: Multiple authors separated with semicolons.
- Aspect values may get normalized to deal with some peculiarities of the current inventory. Example: Specification of years.

## New tables

The mapping of aspects to attributes is defined in a new table `aspect_def`:

```sql
create table preprocess.aspect_def (
    name text primary key,
    keys text[],
    split_at_semicolon boolean,
    normalize_year boolean
);
;
```

Some example aspect definitions:

name | keys | split_at_semicolon | normalize_year
---- | ---- | ------------------ | --------------
`subject` | `subject` | true | false
`title` | `title`, `title-translated`, `title-contrib` | false | false
`person` | `author`, `author-contrib`, `author.fullname_comma`, `advisor`, `referee` | true | false
`year` | `year`, `year-accepted` | false | true

The attributes of every document get stored preprocessed in the new table `aspect`:

```sql
create table preprocess.aspect (
    nid int4 references mediatum.node(id) on delete cascade,
    name text,
    values text[] not null,
    tsvec tsvector not null,
    primary key (nid, name)
);
```

The column `values` is intended for querying facet values and for filtering on facet values.
The column `tsvec` is intended for full-text search on aspects.
