### PR TITLE
Filtering by aspect

### DIFF
--- a/backend/src/sql/api-document.sql
+++ b/backend/src/sql/api-document.sql
@@ -19,7 +19,7 @@ create or replace function aux.all_documents_limited
     where folder_id = node_lineage.ancestor
     and (all_documents_limited.type is null or document.type = all_documents_limited.type)
     and (all_documents_limited.name is null or document.name = all_documents_limited.name)
-    and (attribute_tests is null or aux.jsonb_test_list (document.attrs, attribute_tests))
+    and (attribute_tests = '{}' or aux.jsonb_test_list (document.attrs, attribute_tests))
     order by document.id desc
     limit "limit"
     ;
@@ -80,7 +80,7 @@ create or replace function api.all_documents_page
                     ( folder_id
                     , nullif(type, 'use null instead of this surrogate dummy')
                     , nullif(name, 'use null instead of this surrogate dummy')
-                    , nullif(attribute_tests, '{}')
+                    , attribute_tests
                     , "limit", "offset"
                     )
             )

--- a/backend/src/sql/api-facets.sql
+++ b/backend/src/sql/api-facets.sql
@@ -70,16 +70,16 @@ create or replace function aux.fts_documents_tsquery_docset
                       from mediatum.noderelation
                       where nid = folder_id and cid = fts.id
                      )
-              and ( aspect_tests is null or 
+              and ( aspect_tests = '{}' or 
                     aux.aspect_tests (document.id, aspect_tests)
                   )
-              and ( attribute_tests is null or 
+              and ( attribute_tests = '{}' or 
                     aux.jsonb_test_list (document.attrs, attribute_tests)
                   )
         ; 
         return res;
     end;
-$$ language plpgsql stable parallel safe;
+$$ language plpgsql strict stable parallel safe;
 
 
 create or replace function api.fts_documents_docset
@@ -94,8 +94,8 @@ create or replace function api.fts_documents_docset
         return aux.fts_documents_tsquery_docset
           ( folder_id
           , aux.custom_to_tsquery (text)
-          , nullif(aspect_tests, '{}')
-          , nullif(attribute_tests, '{}')
+          , aspect_tests
+          , attribute_tests
           );
     end;
 $$ language plpgsql strict stable parallel safe;

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -108,7 +108,7 @@ $$ language sql stable parallel safe rows 100;
 create or replace function aux.fts_paginated
     ( folder_id int4
     , text text
-    , aspect_tests api.aspect_test[]
+    , aspect_internal_tests aux.aspect_internal_tests
     , attribute_tests api.attribute_test[]
     , sorting api.fts_sorting
     , "limit" integer
@@ -134,7 +134,8 @@ create or replace function aux.fts_paginated
             from aux.fts_limited
                 ( folder_id
                 , aux.custom_to_tsquery (text)
-                , aux.internalize_aspect_tests (aspect_tests)
+                    && aspect_internal_tests.combined_tsqu
+                , aspect_internal_tests
                 , attribute_tests
                 , sorting
                 , "limit" + "offset" + 1
@@ -178,7 +179,7 @@ create or replace function aux.fts_documents_paginated
         from aux.fts_paginated
             ( folder_id
             , text
-            , aspect_tests
+            , aux.internalize_aspect_tests (aspect_tests)
             , attribute_tests
             , sorting
             , "limit"

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -209,8 +209,8 @@ create or replace function debug.fts_documents_page_static_sql
                 from aux.fts_documents_paginated
                     ( folder_id
                     , text
-                    , nullif(aspect_tests, '{}')
-                    , nullif(attribute_tests, '{}')
+                    , aspect_tests
+                    , attribute_tests
                     , sorting
                     , "limit", "offset"
                     )
@@ -256,8 +256,8 @@ create or replace function debug.fts_documents_page_plpgsql
             aux.fts_documents_paginated
                 ( folder_id
                 , text
-                , nullif(aspect_tests, '{}')
-                , nullif(attribute_tests, '{}')
+                , aspect_tests
+                , attribute_tests
                 , sorting
                 , "limit", "offset"
                 )
@@ -296,8 +296,8 @@ create or replace function api.fts_documents_page
             '    aux.fts_documents_paginated'
             '        ( $1'
             '        , $2'
-            '        , nullif($3, ''{}'')'
-            '        , nullif($4, ''{}'')'
+            '        , $3'
+            '        , $4'
             '        , $5'
             '        , $6, $7'
             '        )'

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -2,9 +2,11 @@
 -- Publicly exposed GraphQL functions
 -- regarding full-text search.
 
+
 create or replace function aux.fts_limited_by_rank
     ( folder_id int4
     , fts_query tsquery
+    , aspect_tests api.aspect_test[]
     , attribute_tests api.attribute_test[]
     , "limit" integer
     )
@@ -22,6 +24,7 @@ create or replace function aux.fts_limited_by_rank
         from preprocess.ufts
         where ufts.tsvec @@ fts_query
         and exists (select 1 from mediatum.noderelation where nid = folder_id and cid = ufts.nid)
+        and aux.aspect_tests (ufts.nid, aspect_tests)
         and exists
             (select 1
              from entity.document
@@ -40,6 +43,7 @@ $$ language sql stable parallel safe rows 100;
 create or replace function aux.fts_limited_by_date
     ( folder_id int4
     , fts_query tsquery
+    , aspect_tests api.aspect_test[]
     , attribute_tests api.attribute_test[]
     , "limit" integer
     )
@@ -57,6 +61,7 @@ create or replace function aux.fts_limited_by_date
         from preprocess.ufts
         where ufts.tsvec @@ fts_query
         and exists (select 1 from mediatum.noderelation where nid = folder_id and cid = ufts.nid)           
+        and aux.aspect_tests (ufts.nid, aspect_tests)
         and exists
             (select 1
              from entity.document
@@ -76,6 +81,7 @@ $$ language sql stable parallel safe rows 100;
 create or replace function aux.fts_limited
     ( folder_id int4
     , fts_query tsquery
+    , aspect_tests api.aspect_test[]
     , attribute_tests api.attribute_test[]
     , sorting api.fts_sorting
     , "limit" integer
@@ -89,12 +95,12 @@ create or replace function aux.fts_limited
     as $$
             select *
                 from aux.fts_limited_by_date(
-                        folder_id, fts_query, attribute_tests, "limit")
+                        folder_id, fts_query, aspect_tests, attribute_tests, "limit")
                 where sorting = 'by_date'
             union
             select *
                 from aux.fts_limited_by_rank(
-                        folder_id, fts_query, attribute_tests, "limit")
+                        folder_id, fts_query, aspect_tests, attribute_tests, "limit")
                 where sorting = 'by_rank'
 $$ language sql stable parallel safe rows 100;
 
@@ -102,6 +108,7 @@ $$ language sql stable parallel safe rows 100;
 create or replace function aux.fts_paginated
     ( folder_id int4
     , text text
+    , aspect_tests api.aspect_test[]
     , attribute_tests api.attribute_test[]
     , sorting api.fts_sorting
     , "limit" integer
@@ -127,6 +134,7 @@ create or replace function aux.fts_paginated
             from aux.fts_limited
                 ( folder_id
                 , aux.custom_to_tsquery (text)
+                , aspect_tests
                 , attribute_tests
                 , sorting
                 , "limit" + "offset" + 1
@@ -139,6 +147,7 @@ $$ language sql stable parallel safe rows 10;
 create or replace function aux.fts_documents_paginated
     ( folder_id int4
     , text text
+    , aspect_tests api.aspect_test[]
     , attribute_tests api.attribute_test[]
     , sorting api.fts_sorting
     , "limit" integer
@@ -169,6 +178,7 @@ create or replace function aux.fts_documents_paginated
         from aux.fts_paginated
             ( folder_id
             , text
+            , aspect_tests
             , attribute_tests
             , sorting
             , "limit"
@@ -186,6 +196,7 @@ $$ language sql stable parallel safe rows 100;
 create or replace function debug.fts_documents_page_static_sql
     ( folder_id int4
     , text text
+    , aspect_tests api.aspect_test[] default '{}'
     , attribute_tests api.attribute_test[] default '{}'
     , sorting api.fts_sorting default 'by_rank'
     , "limit" integer default 10
@@ -198,6 +209,7 @@ create or replace function debug.fts_documents_page_static_sql
                 from aux.fts_documents_paginated
                     ( folder_id
                     , text
+                    , nullif(aspect_tests, '{}')
                     , nullif(attribute_tests, '{}')
                     , sorting
                     , "limit", "offset"
@@ -219,6 +231,7 @@ $$ language sql strict stable parallel safe;
 create or replace function debug.fts_documents_page_plpgsql
     ( folder_id int4
     , text text
+    , aspect_tests api.aspect_test[] default '{}'
     , attribute_tests api.attribute_test[] default '{}'
     , sorting api.fts_sorting default 'by_rank'
     , "limit" integer default 10
@@ -243,6 +256,7 @@ create or replace function debug.fts_documents_page_plpgsql
             aux.fts_documents_paginated
                 ( folder_id
                 , text
+                , nullif(aspect_tests, '{}')
                 , nullif(attribute_tests, '{}')
                 , sorting
                 , "limit", "offset"
@@ -256,6 +270,7 @@ $$ language plpgsql strict stable parallel safe;
 create or replace function api.fts_documents_page
     ( folder_id int4
     , text text
+    , aspect_tests api.aspect_test[] default '{}'
     , attribute_tests api.attribute_test[] default '{}'
     , sorting api.fts_sorting default 'by_rank'
     , "limit" integer default 10
@@ -268,7 +283,7 @@ create or replace function api.fts_documents_page
         -- We use dynamic SQL execution here in order to avoid generic plan caching.
         execute
             'select'
-            '    $6,'
+            '    $7,'
             '    coalesce'
             '        ( bool_or (has_next_page)'
             '        , false'
@@ -282,19 +297,21 @@ create or replace function api.fts_documents_page
             '        ( $1'
             '        , $2'
             '        , nullif($3, ''{}'')'
-            '        , $4'
-            '        , $5, $6'
+            '        , nullif($4, ''{}'')'
+            '        , $5'
+            '        , $6, $7'
             '        )'
             ';'
         into strict res
-        using folder_id, text, attribute_tests, sorting, "limit", "offset"
+        using folder_id, text, aspect_tests, attribute_tests, sorting, "limit", "offset"
         ;
         return res;
     end;
 $$ language plpgsql strict stable parallel safe;
 
-comment on function api.fts_documents_page (folder_id int4, text text, attribute_tests api.attribute_test[], sorting api.fts_sorting, "limit" integer, "offset" integer) is
-    'Perform a full-text-search on the documents of a folder, sorted by a search rank, optionally filtered by a list of attribute tests.'
+comment on function api.fts_documents_page (folder_id int4, text text, aspect_tests api.aspect_test[], attribute_tests api.attribute_test[], sorting api.fts_sorting, "limit" integer, "offset" integer) is
+    'Perform a full-text-search on the documents of a folder, sorted by a search rank,'
+    ' optionally filtered by a list of aspect tests and a list of attribute tests.'
     ' Sorting of the results is either "by_rank" (default) or "by_date".'
     ' For pagination you may specify a limit (defaults to 10) and an offset (defaults to 0).'
     ;

--- a/backend/src/sql/auxiliary.sql
+++ b/backend/src/sql/auxiliary.sql
@@ -101,7 +101,7 @@ create or replace function aux.aspect_tests (document_id int4, array_of_tests ap
     returns boolean as $$
     declare test api.aspect_test;
     begin
-        foreach test in array (coalesce (array_of_tests, array[]::api.aspect_test[]))
+        foreach test in array array_of_tests
         loop
         	case test.operator
                 when 'equality' then
@@ -126,7 +126,7 @@ create or replace function aux.aspect_tests (document_id int4, array_of_tests ap
         end loop;
         return true;
     end;
-$$ language plpgsql stable parallel safe;
+$$ language plpgsql stable strict parallel safe;
 
 
 -- Strip whitescape from either end of the string.

--- a/backend/src/sql/types.sql
+++ b/backend/src/sql/types.sql
@@ -6,6 +6,7 @@ drop schema if exists debug cascade;
 
 create schema if not exists api;
 create schema if not exists debug;
+create schema if not exists aux;
 
 
 create type api.generic_node as
@@ -334,6 +335,25 @@ comment on column api.aspect_test.operator is
     'The test to perform; maybe "equality" or "fts".';
 comment on column api.aspect_test.value is
     'Comparison value or search term for the aspect to be tested';
+
+
+-- We define an internal representation of a user-defined set of aspect tests,
+-- which which allows for more efficient execution of the tests
+create type aux.aspect_internal_test_equality as
+    ( name text
+    , value text
+    );
+
+create type aux.aspect_internal_test_fts as
+    ( name text
+    , tsqu tsquery
+    );
+
+create type aux.aspect_internal_tests as
+    ( tests_equality aux.aspect_internal_test_equality[]
+    , tests_fts aux.aspect_internal_test_fts[]
+    , combined_tsqu tsquery
+    );
 
 
 create type api.document_result as

--- a/backend/src/sql/types.sql
+++ b/backend/src/sql/types.sql
@@ -316,6 +316,26 @@ comment on column api.attribute_test.extra is
     'Second comparison value, used if operator may take two values, like "ilike" or "daterange"';
 
 
+create type api.aspect_test_operator as enum (
+    'equality', 'fts'
+);
+
+create type api.aspect_test as
+    ( name text
+    , operator api.aspect_test_operator
+    , value text
+    );
+
+comment on type api.aspect_test is
+    'Specification for testing  a single aspect value of a document';
+comment on column api.aspect_test.name is
+    'Name of the aspect to be tested';
+comment on column api.aspect_test.operator is
+    'The test to perform; maybe "equality" or "fts".';
+comment on column api.aspect_test.value is
+    'Comparison value or search term for the aspect to be tested';
+
+
 create type api.document_result as
     ( number integer
     , distance float4


### PR DESCRIPTION
Allow for filtering by aspect values in all relevant query functions that return sets of documents.

Each corresponding API function now accepts an additional parameter `aspectTests`, which is a list of tests. Each element can test either on equality or on FTS-matching on a given aspect.

Example:
```graphql
[ { name: "description", operator: FTS, value: "model" }
  { name: "year", operator: EQUALITY, value: "2010" }
]
```

