### PR TITLE
Fix missing tsvector values in ufts table

### DIFF
--- a/backend/src/sql/preprocess.sql
+++ b/backend/src/sql/preprocess.sql
@@ -38,12 +38,19 @@ create or replace function preprocess.unified_tsvec_from_attrs_and_fulltext
         exc_hint text;
     begin
 	    return
-			setweight(to_tsvector('english_german', attrs), 'A')
+			setweight(
+                to_tsvector(
+                    'english_german',
+                    coalesce (attrs, '{}'::jsonb)
+                    ),
+                'A')
 			||
 			setweight(to_tsvector(
                 'english_german'
                 -- Limit the fulltext length to avoid "string is too long for tsvector (... bytes, max 1048575 bytes)"
-                , left(fulltext, 1048000)
+                , left(
+                    coalesce (fulltext, ''),
+                    1048000)
                 ), 'D');
 
         exception


### PR DESCRIPTION
The column `tsvec` in table `preprocess.ufts` contains the concatenated `tsvector`s built from the fulltext and the attributes of each node.

If either of these values is `null` in the table `mediatum.node` then resulting `tsvec` was erroneously also set to `null`.

As a consequence, documents without fulltext could not be found through FTS on attribute values.
