### PR TITLE
Fix sorting of document lists

### DIFF
--- a/backend/src/sql/api-document.sql
+++ b/backend/src/sql/api-document.sql
@@ -74,6 +74,7 @@ create or replace function aux.all_documents_paginated
                 , attribute_tests
                 , "limit" + "offset" + 1
                 ) as f
+            order by f.id desc
             limit "limit"
             offset "offset";
         end;

--- a/backend/src/sql/api-fts.sql
+++ b/backend/src/sql/api-fts.sql
@@ -140,6 +140,10 @@ create or replace function aux.fts_paginated
                 , sorting
                 , "limit" + "offset" + 1
                 ) as f
+            order by
+                case sorting when 'by_date' then f.recency
+                             when 'by_rank' then f.distance
+                end
             limit "limit"
             offset "offset"
 $$ language sql stable parallel safe rows 10;


### PR DESCRIPTION
Make sure the intermediate results keep the desired ordering
when paginating query results.