### PR TITLE
Show known document counts of ancestor folders and their siblings

### DIFF
--- a/frontend/src/elm/UI/Article.elm
+++ b/frontend/src/elm/UI/Article.elm
@@ -150,8 +150,7 @@ folderCountsForQuery context =
             Nothing
 
         ListingPresentation selection window ->
-            Cache.get context.cache.folderCounts selection
-                |> RemoteData.withDefault FolderCounts.init
+            Cache.Derive.folderCountsOnPath context.cache selection
                 |> Just
 
 


### PR DESCRIPTION
When presenting a document listing the folder tree shows document counts for the folders.

These folders are:
1. The selected folder
2. The children of the selected folder
3. All ancestor folders of the selected folder
4. The siblings of these ancestors

Cases 1 and 2 were already implemented. This PR adds implementation of cases 3 and 4.

So, a user that descends into branches of the tree can still see the counts that were presented on previous steps higher up in the hierarchy,

Note that the counts of cases 3 and 4 are only shown if they are already known from previous queries with appropriate scopes. We don't want to initiate extra `docset` queries in situations where the ancestors have not been visited before, which can only occur if the user jumps directly into a folder without visiting the ancestor folders.
