### PR TITLE
Shorter syntax of URL parameters

### DIFF
--- a/frontend/elm.json
+++ b/frontend/elm.json
@@ -8,6 +8,7 @@
     "dependencies": {
         "direct": {
             "Janiczek/cmd-extra": "1.1.0",
+            "RomanErnst/erl": "2.1.1",
             "dillonkearns/elm-graphql": "5.0.2",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",

--- a/frontend/src/elm/Types/Route/Url.elm
+++ b/frontend/src/elm/Types/Route/Url.elm
@@ -10,154 +10,184 @@ module Types.Route.Url exposing
 
 -}
 
-import Dict
+import Erl
 import Maybe.Extra
-import Parser as ElmParser exposing ((|.), (|=))
-import Set
+import Regex
 import Sort.Dict
 import Types.Aspect as Aspect
 import Types.Id as Id exposing (NodeId)
-import Types.Range as Range
 import Types.Route as Route exposing (Route, RouteParameters, RoutePath(..))
-import Types.SearchTerm
-import Types.Selection as Selection exposing (FtsSorting(..))
+import Types.SearchTerm as SearchTerm
+import Types.Selection exposing (FtsSorting(..))
 import Url exposing (Url)
 import Url.Builder as Builder
-import Url.Parser as Parser exposing ((</>), (<?>), Parser)
-import Url.Parser.Query as QueryParser
 import Utils
 
 
-{-| -}
 parseUrl : Url -> Maybe Route
 parseUrl url =
-    Parser.parse parser url
-
-
-parser : Parser (Route -> a) a
-parser =
-    Parser.map Route <|
-        Parser.oneOf
-            [ Parser.map NoId Parser.top <?> parserParameters
-            , Parser.map OneId parseNodeId <?> parserParameters
-            , Parser.map TwoIds
-                (parseNodeId </> parseNodeId)
-                <?> parserParameters
-            ]
-
-
-parseNodeId : Parser (NodeId -> a) a
-parseNodeId =
-    Parser.custom "NODE_ID" <|
-        String.toInt
-            >> Maybe.map Id.fromInt
-            >> Maybe.andThen
-                (Utils.ensure Id.isValidId)
-
-
-parserParameters : QueryParser.Parser RouteParameters
-parserParameters =
-    QueryParser.map6 RouteParameters
-        (QueryParser.string "fts-term"
-            |> QueryParser.map
-                (Maybe.andThen Types.SearchTerm.fromString)
-        )
-        (QueryParser.enum "fts-sorting"
-            (Dict.fromList [ ( "by-rank", FtsByRank ), ( "by-date", FtsByDate ) ])
-            |> queryParserWithDefault Route.defaultFtsSorting
-        )
-        (QueryParser.custom "filter-by-fts"
-            (List.map
-                (ElmParser.run elmParserFilter
-                    >> Result.toMaybe
-                )
-                >> List.map
-                    (Maybe.andThen
-                        (\( aspectString, searchTermString ) ->
-                            Types.SearchTerm.fromString searchTermString
-                                |> Maybe.map
-                                    (\searchTerm ->
-                                        ( Aspect.fromString aspectString
-                                        , searchTerm
-                                        )
-                                    )
-                        )
-                    )
-                >> Maybe.Extra.values
-                >> Selection.ftsFiltersFromList
-            )
-        )
-        (QueryParser.custom "filter-by-facet"
-            (List.map
-                (ElmParser.run elmParserFilter
-                    >> Result.toMaybe
-                )
-                >> Maybe.Extra.values
-                >> List.map (Tuple.mapFirst Aspect.fromString)
-                >> Selection.facetFiltersFromList
-            )
-        )
-        (QueryParser.int "offset"
-            |> queryParserWithDefault 0
-        )
-        (QueryParser.int "limit"
-            |> queryParserWithDefault Route.defaultLimit
-        )
-
-
-queryParserWithDefault : a -> QueryParser.Parser (Maybe a) -> QueryParser.Parser a
-queryParserWithDefault defaultValue parserOfMaybe =
-    QueryParser.map
-        (Maybe.withDefault defaultValue)
-        parserOfMaybe
-
-
-elmParserYearRange : ElmParser.Parser ( Maybe Int, Maybe Int )
-elmParserYearRange =
-    ElmParser.succeed Tuple.pair
-        |= ElmParser.oneOf
-            [ ElmParser.succeed Just
-                |= ElmParser.int
-            , ElmParser.succeed Nothing
-            ]
-        |. ElmParser.symbol "-"
-        |= ElmParser.oneOf
-            [ ElmParser.succeed Just
-                |= ElmParser.int
-            , ElmParser.succeed Nothing
-            ]
-        |. ElmParser.end
-
-
-elmParserFilter : ElmParser.Parser ( String, String )
-elmParserFilter =
     let
-        isAspectNameCharacter c =
-            Char.isAlphaNum c || c == '_' || c == '.' || c == '-'
-
-        isValueCharacter =
-            always True
+        erl : Erl.Url
+        erl =
+            Erl.parse (Url.toString url)
     in
-    ElmParser.succeed Tuple.pair
-        |= ElmParser.variable
-            { start = isAspectNameCharacter
-            , inner = isAspectNameCharacter
-            , reserved = Set.empty
-            }
-        |. ElmParser.symbol ":"
-        -- TODO: Review the following code. Seems a bit too permissive.
-        --       But note, that the URL design may change anyway.
-        |= ElmParser.oneOf
-            [ ElmParser.succeed ""
-                |. ElmParser.end
-            , ElmParser.succeed identity
-                |= ElmParser.variable
-                    { start = isValueCharacter
-                    , inner = isValueCharacter
-                    , reserved = Set.empty
-                    }
-                |. ElmParser.end
-            ]
+    Maybe.map2 Route
+        (parsePath erl.path)
+        (parseQuery erl.query)
+
+
+parsePath : List String -> Maybe RoutePath
+parsePath segments =
+    case List.map idFromString segments of
+        [] ->
+            Just NoId
+
+        [ Just id1 ] ->
+            Just (OneId id1)
+
+        [ Just id1, Just id2 ] ->
+            Just (TwoIds id1 id2)
+
+        _ ->
+            Nothing
+
+
+idFromString : String -> Maybe NodeId
+idFromString =
+    String.toInt
+        >> Maybe.map Id.fromInt
+        >> Maybe.andThen
+            (Utils.ensure Id.isValidId)
+
+
+parseQuery : List ( String, String ) -> Maybe RouteParameters
+parseQuery =
+    List.foldl
+        (\param ->
+            Maybe.andThen (parseQueryParameter param)
+        )
+        (Just (.parameters Route.initHome))
+
+
+parseQueryParameter : ( String, String ) -> RouteParameters -> Maybe RouteParameters
+parseQueryParameter ( name, value ) routeParameters =
+    case name of
+        "fts-term" ->
+            Just { routeParameters | ftsTerm = SearchTerm.fromString value }
+
+        "fts-sorting" ->
+            case value of
+                "by-rank" ->
+                    Just { routeParameters | ftsSorting = FtsByRank }
+
+                "by-date" ->
+                    Just { routeParameters | ftsSorting = FtsByDate }
+
+                _ ->
+                    Nothing
+
+        "offset" ->
+            String.toInt value
+                |> Maybe.map
+                    (\intValue ->
+                        { routeParameters | offset = intValue }
+                    )
+
+        "limit" ->
+            String.toInt value
+                |> Maybe.map
+                    (\intValue ->
+                        { routeParameters | limit = intValue }
+                    )
+
+        "filter-by-fts" ->
+            case Regex.find regexFilter value of
+                [ { submatches } ] ->
+                    case submatches of
+                        [ Just aspectName, maybeAspectValue ] ->
+                            case Maybe.andThen SearchTerm.fromString maybeAspectValue of
+                                Just searchTerm ->
+                                    Just
+                                        { routeParameters
+                                            | ftsFilters =
+                                                Sort.Dict.insert
+                                                    (Aspect.fromString aspectName)
+                                                    searchTerm
+                                                    routeParameters.ftsFilters
+                                        }
+
+                                Nothing ->
+                                    Just routeParameters
+
+                        _ ->
+                            Nothing
+
+                _ ->
+                    Nothing
+
+        "filter-by-facet" ->
+            case Regex.find regexFilter value of
+                [ { submatches } ] ->
+                    case submatches of
+                        [ Just aspectName, maybeAspectValue ] ->
+                            Just
+                                { routeParameters
+                                    | facetFilters =
+                                        Sort.Dict.insert
+                                            (Aspect.fromString aspectName)
+                                            (maybeAspectValue |> Maybe.withDefault "")
+                                            routeParameters.facetFilters
+                                }
+
+                        _ ->
+                            Nothing
+
+                _ ->
+                    Nothing
+
+        _ ->
+            case Regex.find regexHasOrSearchAspect name of
+                [ { submatches } ] ->
+                    case ( submatches, SearchTerm.fromString value ) of
+                        ( [ Just "search", Just aspect ], Just searchTerm ) ->
+                            Just
+                                { routeParameters
+                                    | ftsFilters =
+                                        Sort.Dict.insert
+                                            (Aspect.fromString aspect)
+                                            searchTerm
+                                            routeParameters.ftsFilters
+                                }
+
+                        ( [ Just "has", Just aspect ], _ ) ->
+                            Just
+                                { routeParameters
+                                    | facetFilters =
+                                        Sort.Dict.insert
+                                            (Aspect.fromString aspect)
+                                            value
+                                            routeParameters.facetFilters
+                                }
+
+                        _ ->
+                            Nothing
+
+                _ ->
+                    Just routeParameters
+
+
+regexFilter : Regex.Regex
+regexFilter =
+    "^(\\w+):(.*)$"
+        |> Regex.fromStringWith { caseInsensitive = False, multiline = True }
+        |> Maybe.withDefault Regex.never
+
+
+regexHasOrSearchAspect : Regex.Regex
+regexHasOrSearchAspect =
+    "^(has|search)-(\\w+)$"
+        |> Regex.fromStringWith { caseInsensitive = False, multiline = True }
+        |> Maybe.withDefault Regex.never
 
 
 {-| -}
@@ -177,7 +207,7 @@ toString route =
         (Maybe.Extra.values
             [ route.parameters.ftsTerm
                 |> Maybe.map
-                    (Types.SearchTerm.toString
+                    (SearchTerm.toString
                         >> Builder.string "fts-term"
                     )
             , buildParameterIfNotDefault
@@ -188,7 +218,7 @@ toString route =
             ++ List.map
                 (\( aspect, searchTerm ) ->
                     Builder.string "filter-by-fts"
-                        (Aspect.toString aspect ++ ":" ++ Types.SearchTerm.toString searchTerm)
+                        (Aspect.toString aspect ++ ":" ++ SearchTerm.toString searchTerm)
                 )
                 (Sort.Dict.toList route.parameters.ftsFilters)
             ++ List.map

--- a/frontend/src/elm/Types/Route/Url.elm
+++ b/frontend/src/elm/Types/Route/Url.elm
@@ -138,13 +138,6 @@ parseQueryParameter ( name, value ) routeParameters =
                     Just routeParameters
 
 
-regexFilter : Regex.Regex
-regexFilter =
-    "^(\\w+):(.*)$"
-        |> Regex.fromStringWith { caseInsensitive = False, multiline = True }
-        |> Maybe.withDefault Regex.never
-
-
 regexHasOrSearchAspect : Regex.Regex
 regexHasOrSearchAspect =
     "^(has|search)-(\\w+)$"

--- a/frontend/src/elm/Types/Route/Url.elm
+++ b/frontend/src/elm/Types/Route/Url.elm
@@ -82,12 +82,12 @@ parseQueryParameter ( name, value ) routeParameters =
                             (SearchTerm.fromString value)
                 }
 
-        "fts-sorting" ->
+        "sort-by" ->
             case value of
-                "by-rank" ->
+                "rank" ->
                     Just { routeParameters | ftsSorting = FtsByRank }
 
-                "by-date" ->
+                "date" ->
                     Just { routeParameters | ftsSorting = FtsByDate }
 
                 _ ->
@@ -174,7 +174,7 @@ toString route =
                         >> Builder.string "fts-term"
                     )
             , buildParameterIfNotDefault
-                (ftsSortingTostring >> Builder.string "fts-sorting")
+                (ftsSortingTostring >> Builder.string "sort-by")
                 Route.defaultFtsSorting
                 route.parameters.ftsSorting
             ]
@@ -209,10 +209,10 @@ ftsSortingTostring : FtsSorting -> String
 ftsSortingTostring ftsSorting =
     case ftsSorting of
         FtsByRank ->
-            "by-rank"
+            "rank"
 
         FtsByDate ->
-            "by-date"
+            "date"
 
 
 buildParameterIfNotDefault : (a -> Builder.QueryParameter) -> a -> a -> Maybe Builder.QueryParameter

--- a/frontend/src/elm/Types/SearchTerm.elm
+++ b/frontend/src/elm/Types/SearchTerm.elm
@@ -1,7 +1,7 @@
 module Types.SearchTerm exposing
     ( SearchTerm
-    , fromString
-    , fromStringWithDefault
+    , fromString, fromStringWithDefault
+    , concatMaybes
     , toString
     , ordering
     )
@@ -12,8 +12,8 @@ module Types.SearchTerm exposing
 # Search term
 
 @docs SearchTerm
-@docs fromString
-@docs fromStringWithDefault
+@docs fromString, fromStringWithDefault
+@docs concatMaybes
 @docs toString
 @docs ordering
 
@@ -53,6 +53,24 @@ fromStringWithDefault : String -> String -> SearchTerm
 fromStringWithDefault default string =
     fromString string
         |> Maybe.withDefault (SearchTerm default)
+
+
+{-| Concat search terms, wrapped in Maybe
+-}
+concatMaybes : Maybe SearchTerm -> Maybe SearchTerm -> Maybe SearchTerm
+concatMaybes maybeSearchTerm1 maybeSearchTerm2 =
+    case ( maybeSearchTerm1, maybeSearchTerm2 ) of
+        ( Just (SearchTerm string1), Just (SearchTerm string2) ) ->
+            Just (SearchTerm (string1 ++ " " ++ string2))
+
+        ( Just searchTerm1, Nothing ) ->
+            Just searchTerm1
+
+        ( Nothing, Just searchTerm2 ) ->
+            Just searchTerm2
+
+        ( Nothing, Nothing ) ->
+            Nothing
 
 
 {-| -}

--- a/frontend/tests/Tests/Types.elm
+++ b/frontend/tests/Tests/Types.elm
@@ -136,7 +136,11 @@ fuzzerFtsFilter =
 
 fuzzerFacetFilters : Fuzzer FacetFilters
 fuzzerFacetFilters =
-    Fuzz.map2 Tuple.pair fuzzerAspectName Fuzz.string
+    Fuzz.map2 Tuple.pair
+        fuzzerAspectName
+        -- Do we want to test values with newlines or not?
+        -- Fuzz.string
+        (Fuzz.string |> Fuzz.map (String.filter ((/=) '\n')))
         |> shortList 3
         |> Fuzz.map Types.Selection.facetFiltersFromList
 

--- a/frontend/tests/Tests/Types.elm
+++ b/frontend/tests/Tests/Types.elm
@@ -139,8 +139,8 @@ fuzzerFacetFilters =
     Fuzz.map2 Tuple.pair
         fuzzerAspectName
         -- Do we want to test values with newlines or not?
-        -- Fuzz.string
-        (Fuzz.string |> Fuzz.map (String.filter ((/=) '\n')))
+        Fuzz.string
+        -- (Fuzz.string |> Fuzz.map (String.filter ((/=) '\n')))
         |> shortList 3
         |> Fuzz.map Types.Selection.facetFiltersFromList
 

--- a/frontend/tests/Tests/Types/Route/Url.elm
+++ b/frontend/tests/Tests/Types/Route/Url.elm
@@ -165,6 +165,23 @@ suite =
                             , .parameters >> .facetFilters >> Sort.Dict.get (Aspect.fromString "author") >> Expect.equal (Just " ")
                             ]
                 ]
+            , describe "Multiple search terms on the same aspect should be concatenated"
+                [ testString "https://example.com/?fts-term=f1&search-author=a1&fts-term=f2&search-author=a2" <|
+                    Url.fromString
+                        >> Maybe.andThen Types.Route.Url.parseUrl
+                        >> justAndThenAll
+                            [ .parameters >> .ftsTerm >> expectJustSearchTerm "f1 f2"
+                            , .parameters >> .ftsFilters >> Sort.Dict.get (Aspect.fromString "author") >> expectJustSearchTerm "a1 a2"
+                            ]
+                ]
+            , describe "On multiple values of a facet filter on the same aspect: the last value should win"
+                [ testString "https://example.com/213?has-title=t1&has-title=t2" <|
+                    Url.fromString
+                        >> Maybe.andThen Types.Route.Url.parseUrl
+                        >> justAndThenAll
+                            [ .parameters >> .facetFilters >> Sort.Dict.get (Aspect.fromString "title") >> Expect.equal (Just "t2")
+                            ]
+                ]
             , testString "https://example.com/789/?search-title=%20foo%20\"bar%20%20baz\"" <|
                 Url.fromString
                     >> Maybe.andThen Types.Route.Url.parseUrl

--- a/frontend/tests/Tests/Types/Route/Url.elm
+++ b/frontend/tests/Tests/Types/Route/Url.elm
@@ -81,7 +81,7 @@ suite =
                         , .parameters >> .ftsTerm >> expectJustSearchTerm "foo"
                         , Types.Route.Url.toString >> Expect.equal "/?fts-term=foo"
                         ]
-            , testString "https://example.com/?fts-sorting=by-rank" <|
+            , testString "https://example.com/?sort-by=rank" <|
                 Url.fromString
                     >> Maybe.andThen Types.Route.Url.parseUrl
                     >> justAndThenAll
@@ -92,10 +92,10 @@ suite =
                             >> Expect.equal
                                 (Route.defaultFtsSorting
                                     == FtsByRank
-                                    |> Utils.ifElse "/" "/?fts-sorting=by-rank"
+                                    |> Utils.ifElse "/" "/?sort-by=rank"
                                 )
                         ]
-            , testString "https://example.com/?fts-sorting=by-date" <|
+            , testString "https://example.com/?sort-by=date" <|
                 Url.fromString
                     >> Maybe.andThen Types.Route.Url.parseUrl
                     >> justAndThenAll
@@ -106,7 +106,7 @@ suite =
                             >> Expect.equal
                                 (Route.defaultFtsSorting
                                     == FtsByDate
-                                    |> Utils.ifElse "/" "/?fts-sorting=by-date"
+                                    |> Utils.ifElse "/" "/?sort-by=date"
                                 )
                         ]
             , testString "https://example.com/123/456?fts-term=foo" <|

--- a/frontend/tests/Tests/Types/SearchTerm.elm
+++ b/frontend/tests/Tests/Types/SearchTerm.elm
@@ -50,6 +50,8 @@ fuzzerSearchTerm =
             |> List.map Fuzz.constant
             |> Fuzz.oneOf
         , Fuzz.string
+            |> Fuzz.map
+                (String.filter ((/=) '\n'))
         ]
         |> Fuzz.map
             (SearchTerm.fromStringWithDefault "baz")


### PR DESCRIPTION
parameter    | old syntax                   | new syntax
-------------|------------------------------|-------------------
sorting      | `fts-sorting=by-date`        | `sort-by=date`
fts filter   | `filter-by-fts=title:foo`    | `search-title=foo`
facet filter | `filter-by-facet=author:bar` | `has-author=bar`

Note on the implementation:

For parsing query parameters with dynamic keys we switched from package `elm/url` to utilizing package `RomanErnst/erl`, which provides the query parameters as a list of key-value-pairs.
