### PR TITLE
Selectable UI languages: English and German

### DIFF
--- a/frontend/elm.json
+++ b/frontend/elm.json
@@ -23,6 +23,7 @@
             "elm-community/list-extra": "8.2.4",
             "elm-community/maybe-extra": "5.2.0",
             "elm-community/string-extra": "4.0.1",
+            "jorgengranseth/elm-string-format": "1.0.1",
             "krisajenkins/remotedata": "6.0.1",
             "matthewsj/elm-ordering": "2.0.0",
             "mgold/elm-nonempty-list": "4.1.0",

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -47,6 +47,18 @@ header .title {
 header .subtitle {
   font-size: 80%;
 }
+.language-select {
+  margin-right: 20px;
+  font-size: initial;
+  font-weight: initial;
+}
+.language-select .selected {
+  font-weight: bold;
+}
+.language-select .language-option:hover {
+  text-decoration: underline;
+}
+
 main {
   flex: 1;
   display: flex;
@@ -312,7 +324,4 @@ ul.folder-list ul.folder-list {
 }
 .facet-value-count {
   margin-left: 0.2em;
-}
-.facet-aspects-input {
-  
 }

--- a/frontend/src/assets/index.html
+++ b/frontend/src/assets/index.html
@@ -13,5 +13,9 @@
         "userSelectedUILanguageTag": localStorage.getItem("selectedUILanguage")
       }
     });
+    app.ports.saveSelectedUILanguageTag.subscribe(
+      function (userSelectedUILanguageTag) {
+        localStorage.setItem("selectedUILanguage", userSelectedUILanguageTag);
+      });
   </script>
 </body>

--- a/frontend/src/assets/index.html
+++ b/frontend/src/assets/index.html
@@ -17,5 +17,11 @@
       function (userSelectedUILanguageTag) {
         localStorage.setItem("selectedUILanguage", userSelectedUILanguageTag);
       });
+    window.addEventListener('storage', function (ev) {
+      console.log("StorageEvent: %s %o", ev.newValue, ev);
+      if (ev.key == "selectedUILanguage") {
+        app.ports.changedSelectedUILanguageTag.send(ev.newValue);
+      }
+    });
   </script>
 </body>

--- a/frontend/src/assets/index.html
+++ b/frontend/src/assets/index.html
@@ -9,7 +9,8 @@
   <script>
     var app = Elm.Main.init({
       flags: {
-        "navigator.language": navigator.language
+        "navigatorLanguageTag": navigator.language,
+        "userSelectedUILanguageTag": localStorage.getItem("selectedUILanguage")
       }
     });
   </script>

--- a/frontend/src/assets/index.html
+++ b/frontend/src/assets/index.html
@@ -20,7 +20,11 @@
     window.addEventListener('storage', function (ev) {
       console.log("StorageEvent: %s %o", ev.newValue, ev);
       if (ev.key == "selectedUILanguage") {
-        app.ports.changedSelectedUILanguageTag.send(ev.newValue);
+        app.ports.jsConfigChangeEvent.send(
+          {
+            "userSelectedUILanguageTag": ev.newValue
+          }
+        );
       }
     });
   </script>

--- a/frontend/src/assets/index.html
+++ b/frontend/src/assets/index.html
@@ -7,6 +7,10 @@
 
 <body>
   <script>
-    var app = Elm.Main.init();
+    var app = Elm.Main.init({
+      flags: {
+        "navigator.language": navigator.language
+      }
+    });
   </script>
 </body>

--- a/frontend/src/assets/index.html
+++ b/frontend/src/assets/index.html
@@ -22,10 +22,17 @@
       if (ev.key == "selectedUILanguage") {
         app.ports.jsConfigChangeEvent.send(
           {
-            "userSelectedUILanguageTag": ev.newValue
+            "changedSelectedUILanguageTag": ev.newValue
           }
         );
       }
     });
-  </script>
+    window.addEventListener('languagechange', function () {
+      console.log('languagechange event detected! %s', navigator.language);
+      app.ports.jsConfigChangeEvent.send(
+        {
+          "changedNavigatorLanguageTag": navigator.language
+        }
+      );
+    });  </script>
 </body>

--- a/frontend/src/elm/Main.elm
+++ b/frontend/src/elm/Main.elm
@@ -39,7 +39,7 @@ main =
     Browser.application
         { init = init
         , update = update
-        , subscriptions = always Sub.none
+        , subscriptions = subscriptions
         , view = view
         , onUrlRequest = UrlRequest -- << Debug.log "onUrlRequest"
         , onUrlChange = UrlChanged -- << Debug.log "onUrlChange"
@@ -67,6 +67,11 @@ init flags url navigationKey =
       }
     , Cmd.map SetupMsg setupCmd
     )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Setup.subscriptions model.setup |> Sub.map SetupMsg
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/frontend/src/elm/Main.elm
+++ b/frontend/src/elm/Main.elm
@@ -18,6 +18,7 @@ module Main exposing (main)
 import Browser
 import Browser.Navigation
 import Html
+import Json.Decode
 import Setup
 import Types.Config as Config
 import Types.Route as Route
@@ -33,7 +34,7 @@ type alias Model =
 
 {-| Define the application ingredients.
 -}
-main : Program () Model Msg
+main : Program Json.Decode.Value Model Msg
 main =
     Browser.application
         { init = init
@@ -51,11 +52,12 @@ type Msg
     | SetupMsg Setup.Msg
 
 
-init : () -> Url -> Browser.Navigation.Key -> ( Model, Cmd Msg )
+init : Json.Decode.Value -> Url -> Browser.Navigation.Key -> ( Model, Cmd Msg )
 init flags url navigationKey =
     let
         ( setupModel, setupCmd ) =
             Setup.init
+                flags
                 (Types.Route.Url.parseUrl Config.init url
                     |> Maybe.withDefault (Route.initHome Config.init)
                 )

--- a/frontend/src/elm/Setup.elm
+++ b/frontend/src/elm/Setup.elm
@@ -62,7 +62,7 @@ Note that the latter is delayed until config is known from received ServerSetup.
 init : Json.Decode.Value -> Route -> ( Model, Cmd Msg )
 init flags route =
     ( { delayedInitWithRoute = Just route
-      , config = Config.init |> Config.updateFromFlags flags
+      , config = Config.initFromFlags flags
       , app = App.initEmptyModel
       }
     , Api.sendQueryRequest

--- a/frontend/src/elm/Setup.elm
+++ b/frontend/src/elm/Setup.elm
@@ -133,15 +133,30 @@ update msg model =
             let
                 ( appModel, appCmd, appReturn ) =
                     App.update (appContext model) appMsg model.app
-            in
-            ( { model | app = appModel }
-            , Cmd.map AppMsg appCmd
-            , case appReturn of
-                App.NoReturn ->
-                    NoReturn
 
-                App.ReflectRoute route ->
-                    ReflectRoute True route
+                ( config, return ) =
+                    case appReturn of
+                        App.NoReturn ->
+                            ( model.config
+                            , NoReturn
+                            )
+
+                        App.SwitchUILanguage language ->
+                            ( model.config |> Config.setUiLanguage language
+                            , NoReturn
+                            )
+
+                        App.ReflectRoute route ->
+                            ( model.config
+                            , ReflectRoute True route
+                            )
+            in
+            ( { model
+                | config = config
+                , app = appModel
+              }
+            , Cmd.map AppMsg appCmd
+            , return
             )
 
 

--- a/frontend/src/elm/Setup.elm
+++ b/frontend/src/elm/Setup.elm
@@ -43,7 +43,7 @@ type alias Model =
 
 {-| -}
 type Msg
-    = ChangedSelectedUILanguageTag String
+    = JSConfigChangeEvent Json.Decode.Value
     | ApiResponseServerSetup (Api.Response ServerSetup)
     | AppMsg App.Msg
 
@@ -51,7 +51,7 @@ type Msg
 port saveSelectedUILanguageTag : String -> Cmd msg
 
 
-port changedSelectedUILanguageTag : (String -> msg) -> Sub msg
+port jsConfigChangeEvent : (Json.Decode.Value -> msg) -> Sub msg
 
 
 {-| Initialize fetching the ServerSetup as well as the App module
@@ -74,7 +74,7 @@ init flags route =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    changedSelectedUILanguageTag ChangedSelectedUILanguageTag
+    jsConfigChangeEvent JSConfigChangeEvent
 
 
 {-| Report a changed route to the App and update it accordingly.
@@ -108,8 +108,10 @@ requestNeeds model =
 update : Msg -> Model -> ( Model, Cmd Msg, Return )
 update msg model =
     case msg of
-        ChangedSelectedUILanguageTag languageTag ->
-            ( { model | config = Config.updateFromLanguageTag languageTag model.config }
+        JSConfigChangeEvent eventJsonValue ->
+            ( { model
+                | config = Config.updateFromJSConfigChangeEvent eventJsonValue model.config
+              }
             , Cmd.none
             , NoReturn
             )

--- a/frontend/src/elm/Setup.elm
+++ b/frontend/src/elm/Setup.elm
@@ -1,14 +1,14 @@
 port module Setup exposing
     ( Return(..), Model, Msg
     , init
-    , requestNeeds, updateModelFromRoute, update, view
+    , requestNeeds, updateModelFromRoute, subscriptions, update, view
     )
 
 {-| Top-level module sitting between Main and App, to set up the client configuration
 
 @docs Return, Model, Msg
 @docs init
-@docs requestNeeds, updateModelFromRoute, update, view
+@docs requestNeeds, updateModelFromRoute, subscriptions, update, view
 
 -}
 
@@ -43,11 +43,15 @@ type alias Model =
 
 {-| -}
 type Msg
-    = ApiResponseServerSetup (Api.Response ServerSetup)
+    = ChangedSelectedUILanguageTag String
+    | ApiResponseServerSetup (Api.Response ServerSetup)
     | AppMsg App.Msg
 
 
 port saveSelectedUILanguageTag : String -> Cmd msg
+
+
+port changedSelectedUILanguageTag : (String -> msg) -> Sub msg
 
 
 {-| Initialize fetching the ServerSetup as well as the App module
@@ -66,6 +70,11 @@ init flags route =
         ApiResponseServerSetup
         Api.Queries.serverSetup
     )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    changedSelectedUILanguageTag ChangedSelectedUILanguageTag
 
 
 {-| Report a changed route to the App and update it accordingly.
@@ -99,6 +108,12 @@ requestNeeds model =
 update : Msg -> Model -> ( Model, Cmd Msg, Return )
 update msg model =
     case msg of
+        ChangedSelectedUILanguageTag languageTag ->
+            ( { model | config = Config.updateFromLanguageTag languageTag model.config }
+            , Cmd.none
+            , NoReturn
+            )
+
         ApiResponseServerSetup (Ok serverSetup) ->
             let
                 model1 =

--- a/frontend/src/elm/Setup.elm
+++ b/frontend/src/elm/Setup.elm
@@ -16,6 +16,7 @@ import Api
 import Api.Queries
 import App
 import Html exposing (Html)
+import Json.Decode
 import Types.Config as Config exposing (Config)
 import Types.Route as Route exposing (Route)
 import Types.ServerSetup exposing (ServerSetup)
@@ -50,10 +51,10 @@ type Msg
 Note that the latter is delayed until config is known from received ServerSetup.
 
 -}
-init : Route -> ( Model, Cmd Msg )
-init route =
+init : Json.Decode.Value -> Route -> ( Model, Cmd Msg )
+init flags route =
     ( { delayedInitWithRoute = Just route
-      , config = Config.init
+      , config = Config.init |> Config.updateFromFlags flags
       , app = App.initEmptyModel
       }
     , Api.sendQueryRequest

--- a/frontend/src/elm/Types/Config.elm
+++ b/frontend/src/elm/Types/Config.elm
@@ -1,6 +1,6 @@
 module Types.Config exposing
     ( Config
-    , init, updateFromFlags, updateFromServerSetup
+    , init, updateFromFlags, updateFromLanguageTag, updateFromServerSetup
     , setUiLanguage
     )
 
@@ -9,7 +9,7 @@ module Types.Config exposing
 Most values are defined in the server and fetched dynamically.
 
 @docs Config
-@docs init, updateFromFlags, updateFromServerSetup
+@docs init, updateFromFlags, updateFromLanguageTag, updateFromServerSetup
 @docs setUiLanguage
 
 -}
@@ -83,6 +83,16 @@ updateFromFlags flagsJsonValue config =
                         |> Maybe.Extra.orList
                         |> Maybe.withDefault config.uiLanguage
             }
+
+
+updateFromLanguageTag : String -> Config -> Config
+updateFromLanguageTag languageTag config =
+    { config
+        | uiLanguage =
+            languageTag
+                |> Localization.languageFromLanguageTag
+                |> Maybe.withDefault config.uiLanguage
+    }
 
 
 decoderFlags : JD.Decoder Flags

--- a/frontend/src/elm/Types/Config/FacetAspectConfig.elm
+++ b/frontend/src/elm/Types/Config/FacetAspectConfig.elm
@@ -38,13 +38,13 @@ get =
 If the given aspect has no configuration (should never happen) then we use the raw aspect name.
 
 -}
-getLabelOrAspectName : Localization.Language -> Aspect -> List FacetAspectConfig -> String
-getLabelOrAspectName language aspect listOfFacetAspectConfigs =
+getLabelOrAspectName : { c | uiLanguage : Localization.Language } -> Aspect -> List FacetAspectConfig -> String
+getLabelOrAspectName config aspect listOfFacetAspectConfigs =
     get aspect listOfFacetAspectConfigs
         |> Maybe.Extra.unwrap
             (Aspect.toString aspect)
             (\facetAspectConfig ->
-                Localization.translation language facetAspectConfig.label
+                Localization.string config facetAspectConfig.label
             )
 
 

--- a/frontend/src/elm/Types/Config/FtsAspectConfig.elm
+++ b/frontend/src/elm/Types/Config/FtsAspectConfig.elm
@@ -38,13 +38,13 @@ get =
 If the given aspect has no configuration (should never happen) then we use the raw aspect name.
 
 -}
-getLabelOrAspectName : Localization.Language -> Aspect -> List FtsAspectConfig -> String
-getLabelOrAspectName language aspect listOfFtsAspectConfigs =
+getLabelOrAspectName : { c | uiLanguage : Localization.Language } -> Aspect -> List FtsAspectConfig -> String
+getLabelOrAspectName config aspect listOfFtsAspectConfigs =
     get aspect listOfFtsAspectConfigs
         |> Maybe.Extra.unwrap
             (Aspect.toString aspect)
             (\ftsAspectConfig ->
-                Localization.translation language ftsAspectConfig.label
+                Localization.string config ftsAspectConfig.label
             )
 
 

--- a/frontend/src/elm/Types/Localization.elm
+++ b/frontend/src/elm/Types/Localization.elm
@@ -2,7 +2,7 @@ module Types.Localization exposing
     ( Language(..)
     , languageFromLanguageTag, languageToLanguageTag
     , Translations
-    , translation
+    , translation, text, string
     )
 
 {-| Types used for localization of the app.
@@ -12,9 +12,11 @@ Currently we offer English and German as UI languages.
 @docs Language
 @docs languageFromLanguageTag, languageToLanguageTag
 @docs Translations
-@docs translation
+@docs translation, text, string
 
 -}
+
+import Html exposing (Html)
 
 
 {-| A text with translations into the supported languages
@@ -31,6 +33,10 @@ type Language
     | LangDe
 
 
+type alias Config c =
+    { c | uiLanguage : Language }
+
+
 {-| -}
 translation : Language -> Translations -> String
 translation language translations =
@@ -40,6 +46,18 @@ translation language translations =
 
         LangDe ->
             translations.de
+
+
+{-| -}
+string : Config c -> Translations -> String
+string config =
+    translation config.uiLanguage
+
+
+{-| -}
+text : Config c -> Translations -> Html msg
+text config translations =
+    Html.text (translation config.uiLanguage translations)
 
 
 {-| -}

--- a/frontend/src/elm/Types/Localization.elm
+++ b/frontend/src/elm/Types/Localization.elm
@@ -1,6 +1,6 @@
 module Types.Localization exposing
     ( Language(..)
-    , languageFromLanguageTag
+    , languageFromLanguageTag, languageToLanguageTag
     , Translations
     , translation
     )
@@ -10,7 +10,7 @@ module Types.Localization exposing
 Currently we offer English and German as UI languages.
 
 @docs Language
-@docs languageFromLanguageTag
+@docs languageFromLanguageTag, languageToLanguageTag
 @docs Translations
 @docs translation
 
@@ -54,3 +54,13 @@ languageFromLanguageTag languageTag =
 
         _ ->
             Nothing
+
+
+languageToLanguageTag : Language -> String
+languageToLanguageTag language =
+    case language of
+        LangEn ->
+            "en"
+
+        LangDe ->
+            "de"

--- a/frontend/src/elm/Types/Localization.elm
+++ b/frontend/src/elm/Types/Localization.elm
@@ -1,5 +1,6 @@
 module Types.Localization exposing
     ( Language(..)
+    , languageFromLanguageTag
     , Translations
     , translation
     )
@@ -9,6 +10,7 @@ module Types.Localization exposing
 Currently we offer English and German as UI languages.
 
 @docs Language
+@docs languageFromLanguageTag
 @docs Translations
 @docs translation
 
@@ -38,3 +40,17 @@ translation language translations =
 
         LangDe ->
             translations.de
+
+
+{-| -}
+languageFromLanguageTag : String -> Maybe Language
+languageFromLanguageTag languageTag =
+    case String.left 2 languageTag of
+        "en" ->
+            Just LangEn
+
+        "de" ->
+            Just LangDe
+
+        _ ->
+            Nothing

--- a/frontend/src/elm/Types/Localization.elm
+++ b/frontend/src/elm/Types/Localization.elm
@@ -2,7 +2,7 @@ module Types.Localization exposing
     ( Language(..)
     , languageFromLanguageTag, languageToLanguageTag
     , Translations
-    , translation, text, string
+    , text, string
     )
 
 {-| Types used for localization of the app.
@@ -12,7 +12,7 @@ Currently we offer English and German as UI languages.
 @docs Language
 @docs languageFromLanguageTag, languageToLanguageTag
 @docs Translations
-@docs translation, text, string
+@docs text, string
 
 -}
 
@@ -38,9 +38,9 @@ type alias Config c =
 
 
 {-| -}
-translation : Language -> Translations -> String
-translation language translations =
-    case language of
+string : Config c -> Translations -> String
+string config translations =
+    case config.uiLanguage of
         LangEn ->
             translations.en
 
@@ -49,15 +49,9 @@ translation language translations =
 
 
 {-| -}
-string : Config c -> Translations -> String
-string config =
-    translation config.uiLanguage
-
-
-{-| -}
 text : Config c -> Translations -> Html msg
 text config translations =
-    Html.text (translation config.uiLanguage translations)
+    Html.text (string config translations)
 
 
 {-| -}

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -17,6 +17,7 @@ import Html.Attributes
 import Html.Events
 import Types.Config exposing (Config)
 import Types.Config.FacetAspectConfig as FacetAspect
+import Types.Localization exposing (Language)
 import Types.Navigation as Navigation exposing (Navigation)
 import Types.Needs
 import Types.Presentation exposing (Presentation(..))
@@ -26,6 +27,7 @@ import UI.Controls
 import UI.Facets
 import UI.Icons
 import UI.Tree
+import UI.Widgets.LanguageSelect
 
 
 {-| Context data provided by the parent module [`App`](App). Used by several functions here.
@@ -47,6 +49,7 @@ type Return
     = NoReturn
     | Navigate Navigation
     | UpdateCacheWithModifiedDocument Document
+    | SwitchUILanguage Language
 
 
 {-| The model comprises the models of the sub-components.
@@ -69,7 +72,8 @@ type alias Model =
 {-| Standard message type, wrapping the messages of the sub-components.
 -}
 type Msg
-    = TreeMsg UI.Tree.Msg
+    = UserSelectedUILanguage Language
+    | TreeMsg UI.Tree.Msg
     | FacetsMsg UI.Facets.Msg
     | ControlsMsg UI.Controls.Msg
     | ArticleMsg UI.Article.Msg
@@ -129,6 +133,12 @@ updateOnChangedPresentation presentation model =
 update : Context -> Msg -> Model -> ( Model, Cmd Msg, Return )
 update context msg model =
     case msg of
+        UserSelectedUILanguage language ->
+            ( model
+            , Cmd.none
+            , SwitchUILanguage language
+            )
+
         TreeMsg subMsg ->
             let
                 ( subModel, subReturn ) =
@@ -243,12 +253,17 @@ view context model =
                         , Html.Events.onClick (ControlsMsg UI.Controls.submitExampleQuery)
                         ]
                         [ Html.text "WIP" ]
-                    , Html.img
-                        [ Html.Attributes.alt "TUM Logo"
-                        , Html.Attributes.src "/logo_tum.png"
-                        , Html.Attributes.style "float" "right"
+                    , Html.div
+                        [ Html.Attributes.style "float" "right" ]
+                        [ UI.Widgets.LanguageSelect.view
+                            context.config.uiLanguage
+                            UserSelectedUILanguage
+                        , Html.img
+                            [ Html.Attributes.alt "TUM Logo"
+                            , Html.Attributes.src "/logo_tum.png"
+                            ]
+                            []
                         ]
-                        []
                     ]
                 ]
             , UI.Controls.view

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -17,7 +17,7 @@ import Html.Attributes
 import Html.Events
 import Types.Config exposing (Config)
 import Types.Config.FacetAspectConfig as FacetAspect
-import Types.Localization exposing (Language)
+import Types.Localization as Localization exposing (Language)
 import Types.Navigation as Navigation exposing (Navigation)
 import Types.Needs
 import Types.Presentation exposing (Presentation(..))
@@ -249,7 +249,12 @@ view context model =
                         [ Html.text "mediaTUM view" ]
                     , Html.span
                         [ Html.Attributes.class "subtitle"
-                        , Html.Attributes.title "You may click here to start an example query."
+                        , Html.Attributes.title
+                            (Localization.string context.config
+                                { en = "You may click here to start an example query."
+                                , de = "Hier klicken, um Beispiel-Anfrage zu starten."
+                                }
+                            )
                         , Html.Events.onClick (ControlsMsg UI.Controls.submitExampleQuery)
                         ]
                         [ Html.text "WIP" ]

--- a/frontend/src/elm/UI/Article/Collection.elm
+++ b/frontend/src/elm/UI/Article/Collection.elm
@@ -24,6 +24,7 @@ import Html exposing (Html)
 import RemoteData
 import Types.Config exposing (Config)
 import Types.Id exposing (FolderId)
+import Types.Localization as Localization
 import UI.Icons
 import Utils.Html
 
@@ -76,10 +77,18 @@ view context model =
             RemoteData.Success folder ->
                 Html.h3 [] <|
                     if Folder.isRoot folder then
-                        [ Html.text "Front page for root of all collections" ]
+                        [ Localization.text context.config
+                            { en = "Front page for root of all collections"
+                            , de = "Startseite für alle Kollektionen"
+                            }
+                        ]
 
                     else
-                        [ Html.text "Front page for collection \""
+                        [ Localization.text context.config
+                            { en = "Front page for collection"
+                            , de = "Startseite für Kollektion"
+                            }
+                        , Html.text " \""
                         , Html.text folder.name
                         , Html.text "\""
                         ]

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -35,6 +35,7 @@ import RemoteData
 import Types exposing (DocumentIdFromSearch)
 import Types.Config exposing (Config)
 import Types.Id exposing (DocumentId)
+import Types.Localization as Localization
 import Types.Route exposing (Route)
 import UI.Icons
 import UI.Widgets.Breadcrumbs
@@ -213,31 +214,37 @@ viewDocument context model document residence =
                     viewAttribute
                     document.attributes
             ]
-        , viewSearchMatching document.searchMatching
+        , viewSearchMatching context.config document.searchMatching
         , viewResidence context residence
         , viewEditAttribute model document
         ]
 
 
-viewSearchMatching : Maybe Document.SearchMatching -> Html msg
-viewSearchMatching =
+viewSearchMatching : Config -> Maybe Document.SearchMatching -> Html msg
+viewSearchMatching config =
     Maybe.Extra.unwrap
-        ""
+        { en = "", de = "" }
         (\{ attributes, fulltext } ->
             case ( attributes, fulltext ) of
                 ( False, False ) ->
-                    ""
+                    { en = "", de = "" }
 
                 ( True, False ) ->
-                    "Suchbegriff in Metadaten gefunden"
+                    { en = "Search term found in metadata"
+                    , de = "Suchbegriff in Metadaten gefunden"
+                    }
 
                 ( False, True ) ->
-                    "Suchbegriff in Volltext gefunden"
+                    { en = "Search term found in fulltext"
+                    , de = "Suchbegriff in Volltext gefunden"
+                    }
 
                 ( True, True ) ->
-                    "Suchbegriff in Metadaten und Volltext gefunden"
+                    { en = "Search term found in metadata and fulltext"
+                    , de = "Suchbegriff in Metadaten und Volltext gefunden"
+                    }
         )
-        >> Html.text
+        >> Localization.text config
 
 
 viewAttribute : Document.Attribute -> Html msg
@@ -262,7 +269,11 @@ viewResidence context residence =
         [ Html.Attributes.class "residence" ]
         [ Html.div
             [ Html.Attributes.class "title" ]
-            [ Html.text "Vorkommen:" ]
+            [ Localization.text context.config
+                { en = "Occurrences:"
+                , de = "Vorkommen:"
+                }
+            ]
         , Html.ul [] <|
             List.map
                 (\lineage ->
@@ -279,6 +290,7 @@ viewResidence context residence =
 
 viewEditAttribute : Model -> Document -> Html Msg
 viewEditAttribute model document =
+    -- TODO: Editing feature will be removed soon. View function not localized for now.
     let
         formDisabled =
             model.mutationState == Pending

--- a/frontend/src/elm/UI/Article/Generic.elm
+++ b/frontend/src/elm/UI/Article/Generic.elm
@@ -22,9 +22,11 @@ import Cache exposing (Cache)
 import Cache.Derive
 import Html exposing (Html)
 import RemoteData exposing (RemoteData(..))
+import String.Format
 import Types exposing (DocumentIdFromSearch, NodeType(..))
 import Types.Config exposing (Config)
 import Types.Id as Id exposing (NodeId)
+import Types.Localization as Localization
 import UI.Icons
 import Utils
 import Utils.Html
@@ -69,7 +71,13 @@ view context model =
             case context.genericParameters of
                 Nothing ->
                     Cache.Derive.getRootFolder context.cache
-                        |> RemoteData.map (always "Going to show the root folder")
+                        |> RemoteData.map
+                            (Localization.string context.config
+                                { en = "Going to show the root folder"
+                                , de = "Laden des Startverzeichnisses"
+                                }
+                                |> always
+                            )
 
                 Just ( nodeId, Nothing ) ->
                     Cache.Derive.getNodeType context.cache nodeId
@@ -78,18 +86,23 @@ view context model =
                             (\nodeType ->
                                 Maybe.map Cache.Derive.CacheDerivationError <|
                                     if nodeType == NodeIsNeither then
-                                        Just <|
-                                            "Node "
-                                                ++ Id.toString nodeId
-                                                ++ " is neither a folder nor a document"
+                                        Localization.string context.config
+                                            { en = "Node {{}} is neither a folder nor a document"
+                                            , de = "Node {{}} ist weder ein Verzeichnis noch ein Dokument"
+                                            }
+                                            |> String.Format.value (Id.toString nodeId)
+                                            |> Just
 
                                     else
                                         Nothing
                             )
                         |> RemoteData.map
-                            (always <|
-                                "Going to show the folder or document "
-                                    ++ Id.toString nodeId
+                            (Localization.string context.config
+                                { en = "Going to show the folder or document {{}}"
+                                , de = "Anzeige des Verzeichnisses oder Dokuments {{}} wird vorbereitet"
+                                }
+                                |> String.Format.value (Id.toString nodeId)
+                                |> always
                             )
 
                 Just ( nodeIdOne, Just documentIdFromSearch ) ->
@@ -108,23 +121,29 @@ view context model =
                                             Nothing
 
                                         ( NodeIsFolder _, _ ) ->
-                                            Just <|
-                                                "Node "
-                                                    ++ Id.toString nodeIdTwo
-                                                    ++ " is not a document"
+                                            Localization.string context.config
+                                                { en = "Node {{}} is not a document"
+                                                , de = "Node {{}} ist kein Dokument"
+                                                }
+                                                |> String.Format.value (Id.toString nodeIdTwo)
+                                                |> Just
 
                                         ( _, _ ) ->
-                                            Just <|
-                                                "Node "
-                                                    ++ Id.toString nodeIdOne
-                                                    ++ " is not a folder"
+                                            Localization.string context.config
+                                                { en = "Node {{}} is not a folder"
+                                                , de = "Node {{}} ist kein Verzeichnis"
+                                                }
+                                                |> String.Format.value (Id.toString nodeIdOne)
+                                                |> Just
                             )
                         |> RemoteData.map
-                            (always <|
-                                "Going to show document "
-                                    ++ Id.toString nodeIdOne
-                                    ++ " in folder"
-                                    ++ Id.toString nodeIdTwo
+                            (Localization.string context.config
+                                { en = "Going to show document {{}} in folder {{}}"
+                                , de = "Anzeige des Dokuments {{}} im Verzeichnis {{}} wird vorbereitet"
+                                }
+                                |> String.Format.value (Id.toString nodeIdOne)
+                                |> String.Format.value (Id.toString nodeIdTwo)
+                                |> always
                             )
     in
     Html.div [] <|

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -37,6 +37,7 @@ import RemoteData
 import Types exposing (Window)
 import Types.Config exposing (Config)
 import Types.Id exposing (DocumentId)
+import Types.Localization as Localization
 import Types.Navigation as Navigation exposing (Navigation)
 import Types.Route as Route
 import Types.Route.Url
@@ -211,7 +212,7 @@ viewDocumentsPage context documentsPage =
                 (viewDocumentResult context)
                 documentsPage.content
             )
-        , viewPaginationButtons documentsPage
+        , viewPaginationButtons context.config documentsPage
         ]
 
 
@@ -248,29 +249,35 @@ viewDocument context number document =
                 viewAttribute
                 document.attributes
             )
-        , viewSearchMatching document.searchMatching
+        , viewSearchMatching context.config document.searchMatching
         ]
 
 
-viewSearchMatching : Maybe Document.SearchMatching -> Html msg
-viewSearchMatching =
+viewSearchMatching : Config -> Maybe Document.SearchMatching -> Html msg
+viewSearchMatching config =
     Maybe.Extra.unwrap
-        ""
+        { en = "", de = "" }
         (\{ attributes, fulltext } ->
             case ( attributes, fulltext ) of
                 ( False, False ) ->
-                    ""
+                    { en = "", de = "" }
 
                 ( True, False ) ->
-                    "Suchbegriff in Metadaten gefunden"
+                    { en = "Search term found in metadata"
+                    , de = "Suchbegriff in Metadaten gefunden"
+                    }
 
                 ( False, True ) ->
-                    "Suchbegriff in Volltext gefunden"
+                    { en = "Search term found in fulltext"
+                    , de = "Suchbegriff in Volltext gefunden"
+                    }
 
                 ( True, True ) ->
-                    "Suchbegriff in Metadaten und Volltext gefunden"
+                    { en = "Search term found in metadata and fulltext"
+                    , de = "Suchbegriff in Metadaten und Volltext gefunden"
+                    }
         )
-        >> Html.text
+        >> Localization.text config
 
 
 maxAttributeStringLength : Int
@@ -328,29 +335,29 @@ viewAttribute attribute =
             Html.text ""
 
 
-viewPaginationButtons : DocumentsPage -> Html Msg
-viewPaginationButtons documentsPage =
+viewPaginationButtons : Config -> DocumentsPage -> Html Msg
+viewPaginationButtons config documentsPage =
     let
-        viewButton : String -> Msg -> Bool -> Html Msg
+        viewButton : Localization.Translations -> Msg -> Bool -> Html Msg
         viewButton label msg enabled =
             Html.button
                 [ Html.Attributes.type_ "button"
                 , Html.Attributes.disabled (not enabled)
                 , Html.Events.onClick msg
                 ]
-                [ Html.text label ]
+                [ Localization.text config label ]
     in
     Html.div
         [ Html.Attributes.style "margin" "4px 0px 8px 0px"
         , Html.Attributes.class "input-group"
         ]
-        [ viewButton "First"
+        [ viewButton { en = "First", de = "zum Anfang" }
             (PickPosition First)
             (documentsPage.offset /= 0)
-        , viewButton "Prev"
+        , viewButton { en = "Prev", de = "zurück" }
             (PickPosition Previous)
             (documentsPage.offset /= 0)
-        , viewButton "Next"
+        , viewButton { en = "Next", de = "weiter" }
             (PickPosition Next)
             documentsPage.hasNextPage
         ]

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -29,7 +29,9 @@ import Html.Attributes
 import Html.Events
 import List.Extra
 import Maybe.Extra
+import Mediatum.Object.Setup exposing (config)
 import RemoteData
+import String.Format
 import Types.Aspect as Aspect exposing (Aspect)
 import Types.Config exposing (Config)
 import Types.Config.FacetAspectConfig as FacetAspect
@@ -241,7 +243,7 @@ view context model =
             [ viewSearch context model
             , viewFtsFilters context.config model
             , viewFacetFilters context
-            , viewSearchButtons model
+            , viewSearchButtons context.config model
             ]
         ]
 
@@ -251,7 +253,11 @@ viewSearch context model =
     Html.div [ Html.Attributes.class "search-bar" ]
         [ Html.label
             [ Html.Attributes.class "search-label" ]
-            [ Html.text "metadata & fulltext" ]
+            [ Localization.text context.config
+                { en = "Metadata & Fulltext"
+                , de = "Metadaten & Volltext"
+                }
+            ]
         , Html.span [ Html.Attributes.class "input-group" ]
             [ Html.input
                 [ Html.Attributes.class "search-input"
@@ -273,8 +279,8 @@ viewSearch context model =
         ]
 
 
-viewSearchButtons : Model -> Html Msg
-viewSearchButtons model =
+viewSearchButtons : Config -> Model -> Html Msg
+viewSearchButtons config model =
     Html.div [ Html.Attributes.class "submit-buttons" ]
         [ Html.button
             [ Html.Attributes.type_ "submit"
@@ -285,7 +291,12 @@ viewSearchButtons model =
                 ]
             , Html.Events.onClick (SetSorting ByRank)
             ]
-            [ UI.Icons.search, Html.text " By Rank" ]
+            [ UI.Icons.search
+            , Localization.text config
+                { en = " By Rank"
+                , de = " Beste zuerst"
+                }
+            ]
         , Html.button
             [ Html.Attributes.type_ "submit"
             , Html.Attributes.classList
@@ -295,7 +306,12 @@ viewSearchButtons model =
                 ]
             , Html.Events.onClick (SetSorting ByDate)
             ]
-            [ UI.Icons.search, Html.text " By Date" ]
+            [ UI.Icons.search
+            , Localization.text config
+                { en = " By Date"
+                , de = " Neueste zuerst"
+                }
+            ]
         ]
 
 
@@ -311,8 +327,18 @@ getSearchFieldPlaceholder context =
                     |> Maybe.map .name
             )
         |> Maybe.Extra.unwrap
-            "Search"
-            (\folderName -> "Search in " ++ folderName)
+            (Localization.string context.config
+                { en = "Search"
+                , de = "Suche"
+                }
+            )
+            (\folderName ->
+                Localization.string context.config
+                    { en = "Search in {{}}"
+                    , de = "Suche in {{}}"
+                    }
+                    |> String.Format.value folderName
+            )
 
 
 viewFtsFilters : Config -> Model -> Html Msg
@@ -350,9 +376,14 @@ viewFtsFilter config aspect searchText =
             [ Html.input
                 [ Html.Attributes.class "search-input"
                 , Html.Attributes.type_ "search"
-                , Html.Attributes.placeholder <|
-                    "Search "
-                        ++ FtsAspect.getLabelOrAspectName config.uiLanguage aspect config.ftsAspects
+                , Html.Attributes.placeholder
+                    (Localization.string config
+                        { en = "Search for {{}}"
+                        , de = "Suche nach {{}}"
+                        }
+                        |> String.Format.value
+                            (FtsAspect.getLabelOrAspectName config.uiLanguage aspect config.ftsAspects)
+                    )
                 , Html.Attributes.value searchText
                 , Html.Events.onInput (SetFtsFilterText aspect)
                 ]

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -369,7 +369,7 @@ viewFtsFilter config aspect searchText =
         [ Html.label
             [ Html.Attributes.class "search-label" ]
             [ Html.text
-                (FtsAspect.getLabelOrAspectName config.uiLanguage aspect config.ftsAspects)
+                (FtsAspect.getLabelOrAspectName config aspect config.ftsAspects)
             ]
         , Html.span
             [ Html.Attributes.class "input-group" ]
@@ -382,7 +382,7 @@ viewFtsFilter config aspect searchText =
                         , de = "Suche nach {{}}"
                         }
                         |> String.Format.value
-                            (FtsAspect.getLabelOrAspectName config.uiLanguage aspect config.ftsAspects)
+                            (FtsAspect.getLabelOrAspectName config aspect config.ftsAspects)
                     )
                 , Html.Attributes.value searchText
                 , Html.Events.onInput (SetFtsFilterText aspect)
@@ -414,7 +414,7 @@ viewFtsAspectButtons config ftsFilterLines =
                                 , Html.Attributes.class "add-filter-button"
                                 , Html.Events.onClick <| AddFtsFilter aspect
                                 ]
-                                [ Html.text (Localization.translation config.uiLanguage label) ]
+                                [ Localization.text config label ]
                             ]
 
                 else
@@ -440,7 +440,7 @@ viewFacetFilter config ( aspect, value ) =
         [ Html.label
             [ Html.Attributes.class "search-label" ]
             [ Html.text
-                (FacetAspect.getLabelOrAspectName config.uiLanguage aspect config.facetAspects)
+                (FacetAspect.getLabelOrAspectName config aspect config.facetAspects)
             ]
         , Html.span
             [ Html.Attributes.class "input-group" ]

--- a/frontend/src/elm/UI/Facets.elm
+++ b/frontend/src/elm/UI/Facets.elm
@@ -114,14 +114,13 @@ viewFacet context selection facetAspectConfig =
         [ Html.Attributes.class "facet-box" ]
         [ Html.div
             [ Html.Attributes.class "facet-name" ]
-            [ Html.text
-                (Localization.translation context.config.uiLanguage facetAspectConfig.label)
-            ]
+            [ Localization.text context.config facetAspectConfig.label ]
         , Html.div
             [ Html.Attributes.class "facet-values" ]
             [ case FilterList.get facetAspectConfig.aspect selection.facetFilters of
                 Just selectedValue ->
                     viewFacetSelection
+                        context.config
                         facetAspectConfig.aspect
                         selectedValue
                         (Cache.Derive.getDocumentCount context.cache selection
@@ -148,6 +147,7 @@ viewFacet context selection facetAspectConfig =
 
                         RemoteData.Success facetsValues ->
                             viewFacetValues
+                                context.config
                                 facetAspectConfig.aspect
                                 (Sort.Dict.get facetAspectConfig.aspect facetsValues
                                     |> Maybe.withDefault []
@@ -156,8 +156,8 @@ viewFacet context selection facetAspectConfig =
         ]
 
 
-viewFacetSelection : Aspect -> String -> Maybe Int -> Html Msg
-viewFacetSelection aspect selectedValue maybeCount =
+viewFacetSelection : Config -> Aspect -> String -> Maybe Int -> Html Msg
+viewFacetSelection config aspect selectedValue maybeCount =
     Html.ul [] <|
         [ Html.li
             [ Html.Attributes.class "facet-value-line facet-remove-filter"
@@ -165,7 +165,13 @@ viewFacetSelection aspect selectedValue maybeCount =
             ]
             [ Html.span
                 [ Html.Attributes.class "facet-value-text" ]
-                [ Html.i [] [ Html.text "<< All" ] ]
+                [ Html.i []
+                    [ Localization.text config
+                        { en = "<< All"
+                        , de = "<< zurück"
+                        }
+                    ]
+                ]
             ]
         , Html.li
             [ Html.Attributes.class "facet-value-line"
@@ -174,7 +180,7 @@ viewFacetSelection aspect selectedValue maybeCount =
             [ Html.span
                 [ Html.Attributes.class "facet-value-text" ]
                 [ if String.isEmpty selectedValue then
-                    Html.i [] [ Html.text "[not specified]" ]
+                    viewNotSpecified config
 
                   else
                     Html.text selectedValue
@@ -191,8 +197,8 @@ viewFacetSelection aspect selectedValue maybeCount =
         ]
 
 
-viewFacetValues : Aspect -> FacetValues -> Html Msg
-viewFacetValues aspect facetValues =
+viewFacetValues : Config -> Aspect -> FacetValues -> Html Msg
+viewFacetValues config aspect facetValues =
     Html.ul [] <|
         List.map
             (\{ value, count } ->
@@ -203,7 +209,7 @@ viewFacetValues aspect facetValues =
                     [ Html.span
                         [ Html.Attributes.class "facet-value-text" ]
                         [ if String.isEmpty value then
-                            Html.i [] [ Html.text "[not specified]" ]
+                            viewNotSpecified config
 
                           else
                             Html.text value
@@ -214,3 +220,13 @@ viewFacetValues aspect facetValues =
                     ]
             )
             facetValues
+
+
+viewNotSpecified : Config -> Html msg
+viewNotSpecified config =
+    Html.i []
+        [ Localization.text config
+            { en = "[not specified]"
+            , de = "[nicht angegeben]"
+            }
+        ]

--- a/frontend/src/elm/UI/Widgets/LanguageSelect.elm
+++ b/frontend/src/elm/UI/Widgets/LanguageSelect.elm
@@ -1,0 +1,35 @@
+module UI.Widgets.LanguageSelect exposing (view)
+
+{-|
+
+@docs Context
+@docs view
+
+-}
+
+import Html exposing (Html)
+import Html.Attributes
+import Html.Events
+import Types.Localization as Localization exposing (Language)
+
+
+{-| -}
+view : Language -> (Language -> msg) -> Html msg
+view uiLanguage msgFromLanguage =
+    Html.span [ Html.Attributes.class "language-select" ]
+        [ Html.span
+            [ Html.Events.onClick (msgFromLanguage Localization.LangDe)
+            , Html.Attributes.class "language-option"
+            , Html.Attributes.classList
+                [ ( "selected", uiLanguage == Localization.LangDe ) ]
+            ]
+            [ Html.text "de" ]
+        , Html.text " | "
+        , Html.span
+            [ Html.Events.onClick (msgFromLanguage Localization.LangEn)
+            , Html.Attributes.class "language-option"
+            , Html.Attributes.classList
+                [ ( "selected", uiLanguage == Localization.LangEn ) ]
+            ]
+            [ Html.text "en" ]
+        ]


### PR DESCRIPTION
Localization of the UI for English and German languages.

- Global management of `uiLanguage` in type `Config`.
- Default language is derived from browser's preferences.
- User can override the default with a small "en | de" widget. Selection is saved in local storage.
- If running in multiple windows the app notifies all other windows on a language change.
- All relevant UI texts have been translated, so that we now have English and German versions.
- The UI texts are located in the corresponding view functions (as opposed to a central location). Note that we don't have that many texts at the moment.
- Some translatable texts are defined by the server, in particular the display-names of the aspects provided for FTS and facets. These texts are queried at startup via the `setup` API function.