### PR TITLE
Move language-setup values from config to Setup.Model

### DIFF
--- a/frontend/src/assets/index.html
+++ b/frontend/src/assets/index.html
@@ -18,7 +18,6 @@
         localStorage.setItem("selectedUILanguage", userSelectedUILanguageTag);
       });
     window.addEventListener('storage', function (ev) {
-      console.log("StorageEvent: %s %o", ev.newValue, ev);
       if (ev.key == "selectedUILanguage") {
         app.ports.jsConfigChange.send(
           {
@@ -28,7 +27,6 @@
       }
     });
     window.addEventListener('languagechange', function () {
-      console.log('languagechange event detected! %s', navigator.language);
       app.ports.jsConfigChange.send(
         {
           "changedNavigatorLanguageTag": navigator.language

--- a/frontend/src/assets/index.html
+++ b/frontend/src/assets/index.html
@@ -20,7 +20,7 @@
     window.addEventListener('storage', function (ev) {
       console.log("StorageEvent: %s %o", ev.newValue, ev);
       if (ev.key == "selectedUILanguage") {
-        app.ports.jsConfigChangeEvent.send(
+        app.ports.jsConfigChange.send(
           {
             "changedSelectedUILanguageTag": ev.newValue
           }
@@ -29,7 +29,7 @@
     });
     window.addEventListener('languagechange', function () {
       console.log('languagechange event detected! %s', navigator.language);
-      app.ports.jsConfigChangeEvent.send(
+      app.ports.jsConfigChange.send(
         {
           "changedNavigatorLanguageTag": navigator.language
         }

--- a/frontend/src/elm/Setup.elm
+++ b/frontend/src/elm/Setup.elm
@@ -16,9 +16,10 @@ import Api
 import Api.Queries
 import App
 import Html exposing (Html)
-import Json.Decode
+import Json.Decode as JD
+import Maybe.Extra
 import Types.Config as Config exposing (Config)
-import Types.Localization as Localization
+import Types.Localization as Localization exposing (Language)
 import Types.Route as Route exposing (Route)
 import Types.ServerSetup exposing (ServerSetup)
 
@@ -35,7 +36,9 @@ type Return
 
 {-| -}
 type alias Model =
-    { delayedInitWithRoute : Maybe Route
+    { navigatorLanguage : Maybe Language
+    , userSelectedUILanguage : Maybe Language
+    , delayedInitWithRoute : Maybe Route
     , config : Config
     , app : App.Model
     }
@@ -43,7 +46,7 @@ type alias Model =
 
 {-| -}
 type Msg
-    = JSConfigChangeEvent Json.Decode.Value
+    = JSConfigChange JD.Value
     | ApiResponseServerSetup (Api.Response ServerSetup)
     | AppMsg App.Msg
 
@@ -51,7 +54,7 @@ type Msg
 port saveSelectedUILanguageTag : String -> Cmd msg
 
 
-port jsConfigChangeEvent : (Json.Decode.Value -> msg) -> Sub msg
+port jsConfigChange : (JD.Value -> msg) -> Sub msg
 
 
 {-| Initialize fetching the ServerSetup as well as the App module
@@ -59,10 +62,22 @@ port jsConfigChangeEvent : (Json.Decode.Value -> msg) -> Sub msg
 Note that the latter is delayed until config is known from received ServerSetup.
 
 -}
-init : Json.Decode.Value -> Route -> ( Model, Cmd Msg )
-init flags route =
-    ( { delayedInitWithRoute = Just route
-      , config = Config.initFromFlags flags
+init : JD.Value -> Route -> ( Model, Cmd Msg )
+init flagsJsonValue route =
+    let
+        flags =
+            decodeFlags flagsJsonValue
+
+        config =
+            Config.init
+                |> Config.adjustUILanguage
+                    flags.navigatorLanguage
+                    flags.storedSelectedUILanguage
+    in
+    ( { navigatorLanguage = Nothing
+      , userSelectedUILanguage = Nothing
+      , delayedInitWithRoute = Just route
+      , config = config
       , app = App.initEmptyModel
       }
     , Api.sendQueryRequest
@@ -72,10 +87,68 @@ init flags route =
     )
 
 
+{-| Parameters passed from JS on startup
+-}
+type alias Flags =
+    { navigatorLanguage : Maybe Language
+    , storedSelectedUILanguage : Maybe Language
+    }
+
+
+decodeFlags : JD.Value -> Flags
+decodeFlags flagsJsonValue =
+    let
+        decoder =
+            JD.map2 Flags
+                (JD.field "navigatorLanguageTag" JD.string
+                    |> JD.maybe
+                    |> JD.map (Maybe.andThen Localization.languageFromLanguageTag)
+                )
+                (JD.field "userSelectedUILanguageTag" JD.string
+                    |> JD.maybe
+                    |> JD.map (Maybe.andThen Localization.languageFromLanguageTag)
+                )
+    in
+    JD.decodeValue decoder flagsJsonValue
+        |> Result.withDefault
+            { navigatorLanguage = Nothing
+            , storedSelectedUILanguage = Nothing
+            }
+
+
+{-| Change-events passed from JS
+-}
+type alias JSConfigChangeEvent =
+    { changedNavigatorLanguage : Maybe Language
+    , changedSelectedUILanguage : Maybe Language
+    }
+
+
+decodeConfigChangeEvent : JD.Value -> JSConfigChangeEvent
+decodeConfigChangeEvent eventJsonValue =
+    let
+        decoder =
+            JD.map2 JSConfigChangeEvent
+                (JD.field "changedNavigatorLanguageTag" JD.string
+                    |> JD.maybe
+                    |> JD.map (Maybe.andThen Localization.languageFromLanguageTag)
+                )
+                (JD.field "changedSelectedUILanguageTag" JD.string
+                    |> JD.maybe
+                    |> JD.map (Maybe.andThen Localization.languageFromLanguageTag)
+                )
+    in
+    JD.decodeValue decoder eventJsonValue
+        |> Result.withDefault
+            { changedNavigatorLanguage = Nothing
+            , changedSelectedUILanguage = Nothing
+            }
+
+
 {-| -}
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    jsConfigChangeEvent JSConfigChangeEvent
+    jsConfigChange JSConfigChange
 
 
 {-| Report a changed route to the App and update it accordingly.
@@ -109,9 +182,29 @@ requestNeeds model =
 update : Msg -> Model -> ( Model, Cmd Msg, Return )
 update msg model =
     case msg of
-        JSConfigChangeEvent eventJsonValue ->
-            ( { model
-                | config = Config.updateFromJSConfigChangeEvent eventJsonValue model.config
+        JSConfigChange eventJsonValue ->
+            let
+                event =
+                    decodeConfigChangeEvent eventJsonValue
+
+                model1 =
+                    { model
+                        | navigatorLanguage =
+                            Maybe.Extra.or
+                                event.changedNavigatorLanguage
+                                model.navigatorLanguage
+                        , userSelectedUILanguage =
+                            Maybe.Extra.or
+                                event.changedSelectedUILanguage
+                                model.userSelectedUILanguage
+                    }
+            in
+            ( { model1
+                | config =
+                    model1.config
+                        |> Config.adjustUILanguage
+                            model1.navigatorLanguage
+                            model1.userSelectedUILanguage
               }
             , Cmd.none
             , NoReturn
@@ -156,29 +249,38 @@ update msg model =
                 ( appModel, appCmd, appReturn ) =
                     App.update (appContext model) appMsg model.app
 
-                ( config, saveSelectedUILanguageCmd, return ) =
+                ( model1, saveSelectedUILanguageCmd, return ) =
                     case appReturn of
                         App.NoReturn ->
-                            ( model.config
+                            ( model
                             , Cmd.none
                             , NoReturn
                             )
 
                         App.SwitchUILanguage language ->
-                            ( model.config |> Config.setUiLanguage language
+                            let
+                                model1a =
+                                    { model | userSelectedUILanguage = Just language }
+                            in
+                            ( { model1a
+                                | config =
+                                    model1a.config
+                                        |> Config.adjustUILanguage
+                                            model1a.navigatorLanguage
+                                            model1a.userSelectedUILanguage
+                              }
                             , saveSelectedUILanguageTag (Localization.languageToLanguageTag language)
                             , NoReturn
                             )
 
                         App.ReflectRoute route ->
-                            ( model.config
+                            ( model
                             , Cmd.none
                             , ReflectRoute True route
                             )
             in
-            ( { model
-                | config = config
-                , app = appModel
+            ( { model1
+                | app = appModel
               }
             , [ appCmd, saveSelectedUILanguageCmd ]
                 |> Cmd.batch

--- a/frontend/src/elm/Types/Config.elm
+++ b/frontend/src/elm/Types/Config.elm
@@ -1,8 +1,8 @@
 module Types.Config exposing
     ( Config
-    , init, initFromFlags
-    , updateFromJSConfigChangeEvent, updateFromServerSetup
-    , setUiLanguage
+    , init
+    , updateFromServerSetup
+    , adjustUILanguage
     )
 
 {-| Configuration values used throughout the app.
@@ -10,7 +10,7 @@ module Types.Config exposing
 Most values are defined in the server and fetched dynamically.
 
 @docs Config
-@docs init, initFromFlags
+@docs init
 @docs updateFromJSConfigChangeEvent, updateFromServerSetup
 @docs setUiLanguage
 
@@ -57,99 +57,14 @@ init =
     }
 
 
-{-| Parameters passed from JS on startup
+{-| Set the uiLanguage from given navigatorLanguage and userSelectedUILanguage
 -}
-type alias Flags =
-    { navigatorLanguage : Maybe Language
-    , storedSelectedUILanguage : Maybe Language
-    }
-
-
-decoderFlags : JD.Decoder Flags
-decoderFlags =
-    JD.map2 Flags
-        (JD.field "navigatorLanguageTag" JD.string
-            |> JD.maybe
-            |> JD.map (Maybe.andThen Localization.languageFromLanguageTag)
-        )
-        (JD.field "userSelectedUILanguageTag" JD.string
-            |> JD.maybe
-            |> JD.map (Maybe.andThen Localization.languageFromLanguageTag)
-        )
-
-
-{-| Change-events passed from JS
--}
-type alias JSConfigChangeEvent =
-    { changedNavigatorLanguage : Maybe Language
-    , changedSelectedUILanguage : Maybe Language
-    }
-
-
-decoderConfigChangeEvent : JD.Decoder JSConfigChangeEvent
-decoderConfigChangeEvent =
-    JD.map2 JSConfigChangeEvent
-        (JD.field "changedNavigatorLanguageTag" JD.string
-            |> JD.maybe
-            |> JD.map (Maybe.andThen Localization.languageFromLanguageTag)
-        )
-        (JD.field "changedSelectedUILanguageTag" JD.string
-            |> JD.maybe
-            |> JD.map (Maybe.andThen Localization.languageFromLanguageTag)
-        )
-
-
-{-| -}
-initFromFlags : JD.Value -> Config
-initFromFlags flagsJsonValue =
-    case JD.decodeValue decoderFlags flagsJsonValue of
-        Err err ->
-            init
-
-        Ok flags ->
-            { init
-                | navigatorLanguage = flags.navigatorLanguage
-                , userSelectedUILanguage = flags.storedSelectedUILanguage
-            }
-                |> adjustUILanguage
-
-
-{-| -}
-updateFromJSConfigChangeEvent : JD.Value -> Config -> Config
-updateFromJSConfigChangeEvent eventJsonValue config =
-    case JD.decodeValue decoderConfigChangeEvent eventJsonValue of
-        Err err ->
-            config
-
-        Ok event ->
-            { config
-                | navigatorLanguage =
-                    Maybe.Extra.or
-                        event.changedNavigatorLanguage
-                        config.navigatorLanguage
-                , userSelectedUILanguage =
-                    Maybe.Extra.or
-                        event.changedSelectedUILanguage
-                        config.userSelectedUILanguage
-            }
-                |> adjustUILanguage
-
-
-{-| -}
-setUiLanguage : Language -> Config -> Config
-setUiLanguage language config =
-    { config
-        | userSelectedUILanguage = Just language
-    }
-        |> adjustUILanguage
-
-
-adjustUILanguage : Config -> Config
-adjustUILanguage config =
+adjustUILanguage : Maybe Language -> Maybe Language -> Config -> Config
+adjustUILanguage navigatorLanguage userSelectedUILanguage config =
     { config
         | uiLanguage =
-            [ config.userSelectedUILanguage
-            , config.navigatorLanguage
+            [ userSelectedUILanguage
+            , navigatorLanguage
             ]
                 |> Maybe.Extra.orList
                 |> Maybe.withDefault Localization.LangEn

--- a/frontend/src/elm/Types/Config.elm
+++ b/frontend/src/elm/Types/Config.elm
@@ -11,12 +11,11 @@ Most values are defined in the server and fetched dynamically.
 
 @docs Config
 @docs init
-@docs updateFromJSConfigChangeEvent, updateFromServerSetup
-@docs setUiLanguage
+@docs updateFromServerSetup
+@docs adjustUILanguage
 
 -}
 
-import Json.Decode as JD
 import Maybe exposing (Maybe)
 import Maybe.Extra
 import Types.Config.FacetAspectConfig exposing (FacetAspectConfig)
@@ -29,9 +28,7 @@ import Types.ServerSetup exposing (ServerSetup)
 {-| Configuration values that are made available to most modules via their Context type
 -}
 type alias Config =
-    { navigatorLanguage : Maybe Language
-    , userSelectedUILanguage : Maybe Language
-    , uiLanguage : Language
+    { uiLanguage : Language
     , serverConfigAdopted : Bool
     , defaultPageSize : Int
     , defaultSorting : Selection.Sorting
@@ -45,9 +42,7 @@ type alias Config =
 -}
 init : Config
 init =
-    { navigatorLanguage = Nothing
-    , userSelectedUILanguage = Nothing
-    , uiLanguage = Localization.LangEn
+    { uiLanguage = Localization.LangEn
     , serverConfigAdopted = False
     , defaultPageSize = 10
     , defaultSorting = Selection.ByRank
@@ -57,7 +52,7 @@ init =
     }
 
 
-{-| Set the uiLanguage from given navigatorLanguage and userSelectedUILanguage
+{-| Set the `uiLanguage` from given `navigatorLanguage` and `userSelectedUILanguage`
 -}
 adjustUILanguage : Maybe Language -> Maybe Language -> Config -> Config
 adjustUILanguage navigatorLanguage userSelectedUILanguage config =

--- a/frontend/tests/Tests/Types/Route/Url.elm
+++ b/frontend/tests/Tests/Types/Route/Url.elm
@@ -23,9 +23,7 @@ import Utils
 
 testConfig : Config
 testConfig =
-    { navigatorLanguage = Nothing
-    , userSelectedUILanguage = Nothing
-    , uiLanguage = Localization.LangEn
+    { uiLanguage = Localization.LangEn
     , serverConfigAdopted = True
     , defaultPageSize = 10
     , defaultSorting = ByRank


### PR DESCRIPTION
The values of `navigatorLanguage` and `userSelectedUILanguage` are relevant only within `Setup` module. The globally used `Config` should expose only the derived `uiLanguage` value.

Therefore we move these two values from `Config` to `Setup.Model`.


