### PR TITLE
Configure toplevel folder ids

### DIFF
--- a/backend/src/sql/api-setup.sql
+++ b/backend/src/sql/api-setup.sql
@@ -30,7 +30,8 @@ create type api.masks_purpose_config as
     );
 
 create type api.setup_config as
-    ( default_page_size integer
+    ( toplevel_folders int4[]
+    , default_page_size integer
     , default_sorting api.fts_sorting
     , number_of_facet_values integer
     , static_fts_aspects api.fts_aspect_config[]
@@ -61,6 +62,10 @@ create or replace function api.setup_config
     returns api.setup_config
     as $$
     select
+        (select (toplevel_folder_ids)
+            from config.application
+            where name = 'hsb'
+        ) as toplevel_folders,
     	10 as default_page_size,
     	'by_rank'::api.fts_sorting as default_sorting,
         20 as number_of_facet_values,

--- a/backend/src/sql/config.sql
+++ b/backend/src/sql/config.sql
@@ -13,7 +13,11 @@ create table config.application (
 insert into config.application values
     -- ('hsb', array[604993]) -- 604993 is the root node
     -- ('hsb', array[1433087]) -- 1433087 is the "Hochschulbibliographie" node
-    ('hsb', array[1433088, 1433089, 1515316]) -- Tests multiple root folders, using several years of hsb
+    ('hsb', array[1433088, 1433089, 1515316]) -- Multiple root folders, using several years of hsb
+    -- ('hsb', array[1459256]) -- A directory
+    -- ('hsb', array[1459256, 1433088, 1433089, 1515316]) -- Multiple root folders, using a directory first and then several years of hsb
+    -- ('hsb', array[1433088, 1433089, 1515316, 1459256]) -- Multiple root folders, using several years of hsb first, and a directory last
+    -- ('hsb', '{}') -- No root folder, for testing only
 ;
 
 

--- a/backend/src/sql/config.sql
+++ b/backend/src/sql/config.sql
@@ -5,6 +5,16 @@ drop schema if exists config cascade;
 create schema if not exists config;
 
 
+create table config.application (
+    name text primary key,
+    toplevel_folder_ids int4[]
+);
+
+insert into config.application values
+    ('hsb', array[604993])
+;
+
+
 create table config.aspect_def (
     name text primary key,
     keys text[],

--- a/backend/src/sql/config.sql
+++ b/backend/src/sql/config.sql
@@ -11,7 +11,8 @@ create table config.application (
 );
 
 insert into config.application values
-    ('hsb', array[604993])
+    -- ('hsb', array[604993]) -- 604993 is the root node
+    ('hsb', array[1433087]) -- 1433087 is the "Hochschulbibliographie" node
 ;
 
 

--- a/backend/src/sql/config.sql
+++ b/backend/src/sql/config.sql
@@ -12,8 +12,8 @@ create table config.application (
 
 insert into config.application values
     -- ('hsb', array[604993]) -- 604993 is the root node
-    -- ('hsb', array[1433087]) -- 1433087 is the "Hochschulbibliographie" node
-    ('hsb', array[1433088, 1433089, 1515316]) -- Multiple root folders, using several years of hsb
+    ('hsb', array[1433087]) -- 1433087 is the "Hochschulbibliographie" node
+    -- ('hsb', array[1433088, 1433089, 1515316]) -- Multiple root folders, using several years of hsb
     -- ('hsb', array[1459256]) -- A directory
     -- ('hsb', array[1459256, 1433088, 1433089, 1515316]) -- Multiple root folders, using a directory first and then several years of hsb
     -- ('hsb', array[1433088, 1433089, 1515316, 1459256]) -- Multiple root folders, using several years of hsb first, and a directory last

--- a/backend/src/sql/config.sql
+++ b/backend/src/sql/config.sql
@@ -12,7 +12,8 @@ create table config.application (
 
 insert into config.application values
     -- ('hsb', array[604993]) -- 604993 is the root node
-    ('hsb', array[1433087]) -- 1433087 is the "Hochschulbibliographie" node
+    -- ('hsb', array[1433087]) -- 1433087 is the "Hochschulbibliographie" node
+    ('hsb', array[1433088, 1433089, 1515316]) -- Tests multiple root folders, using several years of hsb
 ;
 
 

--- a/frontend/src/elm/Api/Queries.elm
+++ b/frontend/src/elm/Api/Queries.elm
@@ -90,6 +90,11 @@ serverSetup =
                 (Mediatum.Object.Setup.config
                     (SelectionSet.succeed ServerSetup.ServerConfig
                         |> SelectionSet.with
+                            (Mediatum.Object.SetupConfig.toplevelFolders
+                                |> Api.Fragments.nonNullElementsOfMaybeListOrFail
+                                |> SelectionSet.map (Maybe.map (List.map Id.fromInt))
+                            )
+                        |> SelectionSet.with
                             Mediatum.Object.SetupConfig.defaultPageSize
                         |> SelectionSet.with
                             (Mediatum.Object.SetupConfig.defaultSorting

--- a/frontend/src/elm/Api/Queries.elm
+++ b/frontend/src/elm/Api/Queries.elm
@@ -1,6 +1,6 @@
 module Api.Queries exposing
     ( serverSetup
-    , toplevelFolders, folders, subfolders
+    , folders, subfolders
     , selectionDocumentsPage, selectionFolderCounts, selectionFacets
     , documentDetails
     , genericNode, authorSearch
@@ -130,33 +130,6 @@ serverSetup =
                     )
                     |> SelectionSet.nonNullOrFail
                 )
-        )
-        |> SelectionSet.nonNullOrFail
-
-
-{-| Get the root folders and their sub-folders.
-
-_GraphQL notation:_
-
-    query {
-        allFolders(isRoot: true) {
-            nodes {
-                ...folderAndSubfolders
-            }
-        }
-    }
-
--}
-toplevelFolders : SelectionSet (List ( Folder, List Folder )) Graphql.Operation.RootQuery
-toplevelFolders =
-    Mediatum.Query.allFolders
-        (\optionals ->
-            { optionals
-                | isRoot = Present True
-            }
-        )
-        (Mediatum.Object.FoldersConnection.nodes
-            Api.Fragments.folderAndSubfolders
         )
         |> SelectionSet.nonNullOrFail
 

--- a/frontend/src/elm/Api/Queries.elm
+++ b/frontend/src/elm/Api/Queries.elm
@@ -25,7 +25,7 @@ In reality it's just function calling.
 
 # Folder Queries
 
-@docs toplevelFolders, folders, subfolders
+@docs folders, subfolders
 
 
 # Document Search and Facet Queries

--- a/frontend/src/elm/App.elm
+++ b/frontend/src/elm/App.elm
@@ -113,18 +113,19 @@ updateModelFromRoute context route model =
             }
 
         model3 =
-            adjustPresentation model2
+            adjustPresentation context.config model2
     in
     model3
 
 
 {-| Derive the current presentation from the route using contextual knowledge from the cache and update the UI accordingly.
 -}
-adjustPresentation : Model -> Model
-adjustPresentation model =
+adjustPresentation : Config -> Model -> Model
+adjustPresentation config model =
     let
         presentation =
             Presentation.fromRoute
+                config
                 model.cache
                 model.route
     in
@@ -219,7 +220,7 @@ updateSubModel context msg model =
                     , Cmd.map CacheMsg subCmd
                     )
             in
-            ( model1 |> adjustPresentation
+            ( model1 |> adjustPresentation context.config
             , cmd1
             , SubNoReturn
             )

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -115,8 +115,7 @@ type alias Cache =
 {-| A data-consuming module declares its wishes for API data by means of this type.
 -}
 type Need
-    = NeedRootFolderIds
-    | NeedFolders (List FolderId)
+    = NeedFolders (List FolderId)
     | NeedSubfolders (List FolderId)
     | NeedGenericNode String NodeId
     | NeedDocumentFromSearch String DocumentIdFromSearch
@@ -196,10 +195,6 @@ targetNeeds config needs cache =
 statusOfNeed : Config -> Cache -> Need -> Needs.Status
 statusOfNeed config cache need =
     case need of
-        NeedRootFolderIds ->
-            Needs.statusFromListOfRemoteData
-                (List.map (get cache.folders) config.toplevelFolders)
-
         NeedFolders folderIds ->
             Needs.statusFromListOfRemoteData
                 (List.map (get cache.folders) folderIds)
@@ -239,12 +234,6 @@ Also mark the corresponding cache entries as `RemoteData.Loading`.
 requestNeed : Config -> Need -> Cache -> ( Cache, Cmd Msg )
 requestNeed config need cache =
     case need of
-        NeedRootFolderIds ->
-            requestNeed
-                config
-                (NeedFolders config.toplevelFolders)
-                cache
-
         NeedFolders folderIds ->
             let
                 unknownFolderIds =

--- a/frontend/src/elm/Cache/Derive.elm
+++ b/frontend/src/elm/Cache/Derive.elm
@@ -50,6 +50,7 @@ import Maybe.Extra
 import RemoteData exposing (RemoteData(..))
 import Sort.Dict
 import Types exposing (FolderDisplay(..), NodeType(..))
+import Types.Config exposing (Config)
 import Types.Id as Id exposing (DocumentId, FolderId, NodeId)
 import Types.Selection exposing (Selection)
 
@@ -118,15 +119,11 @@ getAsDocumentId cache nodeId =
 
 
 {-| -}
-getRootFolder : Cache -> DerivedData ( FolderId, FolderDisplay )
-getRootFolder cache =
-    cache.rootFolderIds
-        |> RemoteData.mapError CacheApiError
-        |> RemoteData.andThen
-            (\listOfFolderIds ->
-                List.head listOfFolderIds
-                    |> RemoteData.fromMaybe (CacheDerivationError "List of root folders is empty")
-            )
+getRootFolder : Config -> Cache -> DerivedData ( FolderId, FolderDisplay )
+getRootFolder config cache =
+    config.toplevelFolders
+        |> List.head
+        |> RemoteData.fromMaybe (CacheDerivationError "List of root folders is empty")
         |> RemoteData.andThen
             (\folderId ->
                 Cache.get cache.nodeTypes (folderId |> Id.asNodeId)
@@ -144,9 +141,9 @@ getRootFolder cache =
 
 
 {-| -}
-getRootFolderId : Cache -> Maybe FolderId
-getRootFolderId cache =
-    getRootFolder cache
+getRootFolderId : Config -> Cache -> Maybe FolderId
+getRootFolderId config cache =
+    getRootFolder config cache
         |> RemoteData.toMaybe
         |> Maybe.map Tuple.first
 

--- a/frontend/src/elm/Cache/Derive.elm
+++ b/frontend/src/elm/Cache/Derive.elm
@@ -6,7 +6,6 @@ module Cache.Derive exposing
     , getNodeType
     , getAsFolderId
     , getAsDocumentId
-    , getRootFolder
     , getRootFolderId
     , getParentId
     , getPath
@@ -14,6 +13,7 @@ module Cache.Derive exposing
     , isOnPath
     , getDocumentCount
     , folderCountsOnPath
+    , getFirstRootFolder
     )
 
 {-| Functions for getting/deriving some special data from the base tables in the cache.
@@ -119,8 +119,8 @@ getAsDocumentId cache nodeId =
 
 
 {-| -}
-getRootFolder : Config -> Cache -> DerivedData ( FolderId, FolderDisplay )
-getRootFolder config cache =
+getFirstRootFolder : Config -> Cache -> DerivedData ( FolderId, FolderDisplay )
+getFirstRootFolder config cache =
     config.toplevelFolderIds
         |> List.head
         |> RemoteData.fromMaybe (CacheDerivationError "List of root folders is empty")
@@ -143,7 +143,7 @@ getRootFolder config cache =
 {-| -}
 getRootFolderId : Config -> Cache -> Maybe FolderId
 getRootFolderId config cache =
-    getRootFolder config cache
+    getFirstRootFolder config cache
         |> RemoteData.toMaybe
         |> Maybe.map Tuple.first
 

--- a/frontend/src/elm/Cache/Derive.elm
+++ b/frontend/src/elm/Cache/Derive.elm
@@ -121,7 +121,7 @@ getAsDocumentId cache nodeId =
 {-| -}
 getRootFolder : Config -> Cache -> DerivedData ( FolderId, FolderDisplay )
 getRootFolder config cache =
-    config.toplevelFolders
+    config.toplevelFolderIds
         |> List.head
         |> RemoteData.fromMaybe (CacheDerivationError "List of root folders is empty")
         |> RemoteData.andThen

--- a/frontend/src/elm/Entities/Residence.elm
+++ b/frontend/src/elm/Entities/Residence.elm
@@ -1,13 +1,14 @@
-module Entities.Residence exposing (Residence, toList)
+module Entities.Residence exposing (Residence, limitToToplevelFolders, toList)
 
 {-| The residence of a document, i.e. the set of folders in which the document appears.
 
-@docs Residence, toList
+@docs Residence, limitToToplevelFolders, toList
 
 -}
 
 import List.Nonempty
 import Sort.Set
+import Types.Config exposing (Config)
 import Types.Id as Id exposing (FolderId, LineageIds)
 import Utils
 
@@ -17,6 +18,17 @@ where it is located in the hierarchy.
 -}
 type alias Residence =
     List LineageIds
+
+
+{-| Limit the lineages in relation to a list of toplevel folders.
+
+Drop those lineages that are not rooted in one of the toplevel folders.
+
+-}
+limitToToplevelFolders : Config -> Residence -> Residence
+limitToToplevelFolders config =
+    List.filterMap
+        (Id.limitToToplevelFolders config.toplevelFolderIds)
 
 
 {-| Unique list of all folder ids in the residence.

--- a/frontend/src/elm/Types/Config.elm
+++ b/frontend/src/elm/Types/Config.elm
@@ -34,7 +34,7 @@ import Types.ServerSetup exposing (ServerSetup)
 type alias Config =
     { uiLanguage : Language
     , serverConfigAdopted : Bool
-    , toplevelFolders : List FolderId
+    , toplevelFolderIds : List FolderId
     , defaultPageSize : Int
     , defaultSorting : Selection.Sorting
     , numberOfFacetValues : Int
@@ -50,7 +50,7 @@ init : Config
 init =
     { uiLanguage = Localization.LangEn
     , serverConfigAdopted = False
-    , toplevelFolders = []
+    , toplevelFolderIds = []
     , defaultPageSize = 10
     , defaultSorting = Selection.ByRank
     , numberOfFacetValues = 20
@@ -79,8 +79,8 @@ updateFromServerSetup : ServerSetup -> Config -> Config
 updateFromServerSetup serverSetup config =
     { config
         | serverConfigAdopted = True
-        , toplevelFolders =
-            serverSetup.config.toplevelFolders |> Maybe.withDefault config.toplevelFolders
+        , toplevelFolderIds =
+            serverSetup.config.toplevelFolderIds |> Maybe.withDefault config.toplevelFolderIds
         , defaultPageSize =
             serverSetup.config.defaultPageSize |> Maybe.withDefault config.defaultPageSize
         , defaultSorting =

--- a/frontend/src/elm/Types/Config.elm
+++ b/frontend/src/elm/Types/Config.elm
@@ -22,7 +22,8 @@ import Maybe exposing (Maybe)
 import Maybe.Extra
 import Types.Config.FacetAspectConfig exposing (FacetAspectConfig)
 import Types.Config.FtsAspectConfig exposing (FtsAspectConfig)
-import Types.Config.MasksConfig as MasksConfig exposing (MasksConfig, MasksPurposeServerConfig)
+import Types.Config.MasksConfig as MasksConfig exposing (MasksConfig)
+import Types.Id exposing (FolderId)
 import Types.Localization as Localization exposing (Language)
 import Types.Selection as Selection
 import Types.ServerSetup exposing (ServerSetup)
@@ -33,6 +34,7 @@ import Types.ServerSetup exposing (ServerSetup)
 type alias Config =
     { uiLanguage : Language
     , serverConfigAdopted : Bool
+    , toplevelFolders : List FolderId
     , defaultPageSize : Int
     , defaultSorting : Selection.Sorting
     , numberOfFacetValues : Int
@@ -48,6 +50,7 @@ init : Config
 init =
     { uiLanguage = Localization.LangEn
     , serverConfigAdopted = False
+    , toplevelFolders = []
     , defaultPageSize = 10
     , defaultSorting = Selection.ByRank
     , numberOfFacetValues = 20
@@ -76,6 +79,8 @@ updateFromServerSetup : ServerSetup -> Config -> Config
 updateFromServerSetup serverSetup config =
     { config
         | serverConfigAdopted = True
+        , toplevelFolders =
+            serverSetup.config.toplevelFolders |> Maybe.withDefault config.toplevelFolders
         , defaultPageSize =
             serverSetup.config.defaultPageSize |> Maybe.withDefault config.defaultPageSize
         , defaultSorting =

--- a/frontend/src/elm/Types/Config/MasksConfig.elm
+++ b/frontend/src/elm/Types/Config/MasksConfig.elm
@@ -59,6 +59,8 @@ init =
         }
 
 
+{-| Adopt the configuration from the server
+-}
 updateFromServer : List MasksPurposeServerConfig -> MasksConfig -> MasksConfig
 updateFromServer listOfMasksPurposeServerConfig masksConfig =
     listOfMasksPurposeServerConfig

--- a/frontend/src/elm/Types/Presentation.elm
+++ b/frontend/src/elm/Types/Presentation.elm
@@ -99,7 +99,7 @@ fromRoute config cache route =
     in
     case route.path of
         Route.NoId ->
-            Cache.Derive.getRootFolder config cache
+            Cache.Derive.getFirstRootFolder config cache
                 |> RemoteData.toMaybe
                 |> Maybe.Extra.unwrap
                     (GenericPresentation Nothing)

--- a/frontend/src/elm/Types/Presentation.elm
+++ b/frontend/src/elm/Types/Presentation.elm
@@ -74,11 +74,9 @@ fromRoute config cache route =
     let
         folderPresentation folderId folderType =
             if
-                route.parameters.globalFts
-                    == Nothing
+                (route.parameters.globalFts == Nothing)
                     && FilterList.isEmpty route.parameters.ftsFilters
-                    && folderType
-                    == DisplayAsCollection
+                    && (folderType == DisplayAsCollection)
             then
                 CollectionPresentation folderId
 
@@ -99,12 +97,14 @@ fromRoute config cache route =
     in
     case route.path of
         Route.NoId ->
-            Cache.Derive.getFirstRootFolder config cache
-                |> RemoteData.toMaybe
+            List.head config.toplevelFolderIds
                 |> Maybe.Extra.unwrap
                     (GenericPresentation Nothing)
-                    (\( rootFolderId, rootFolderType ) ->
-                        folderPresentation rootFolderId rootFolderType
+                    (\firstToplevelFolderId ->
+                        Cache.Derive.getFolderDisplay cache firstToplevelFolderId
+                            |> Maybe.Extra.unwrap
+                                (GenericPresentation (Just ( firstToplevelFolderId |> Id.asNodeId, Nothing )))
+                                (folderPresentation firstToplevelFolderId)
                     )
 
         Route.OneId nodeId ->

--- a/frontend/src/elm/Types/Presentation.elm
+++ b/frontend/src/elm/Types/Presentation.elm
@@ -34,6 +34,7 @@ import Cache.Derive
 import Maybe.Extra
 import RemoteData
 import Types exposing (DocumentIdFromSearch, FolderDisplay(..), NodeType(..), Window)
+import Types.Config exposing (Config)
 import Types.FilterList as FilterList
 import Types.Id as Id exposing (FolderId, NodeId)
 import Types.Route as Route exposing (Route)
@@ -68,8 +69,8 @@ getFolderId cache presentation =
 
 
 {-| -}
-fromRoute : Cache -> Route -> Presentation
-fromRoute cache route =
+fromRoute : Config -> Cache -> Route -> Presentation
+fromRoute config cache route =
     let
         folderPresentation folderId folderType =
             if
@@ -98,7 +99,7 @@ fromRoute cache route =
     in
     case route.path of
         Route.NoId ->
-            Cache.Derive.getRootFolder cache
+            Cache.Derive.getRootFolder config cache
                 |> RemoteData.toMaybe
                 |> Maybe.Extra.unwrap
                     (GenericPresentation Nothing)

--- a/frontend/src/elm/Types/ServerSetup.elm
+++ b/frontend/src/elm/Types/ServerSetup.elm
@@ -25,7 +25,7 @@ type alias ServerSetup =
 
 {-| -}
 type alias ServerConfig =
-    { toplevelFolders : Maybe (List FolderId)
+    { toplevelFolderIds : Maybe (List FolderId)
     , defaultPageSize : Maybe Int
     , defaultSorting : Maybe Selection.Sorting
     , numberOfFacetValues : Maybe Int

--- a/frontend/src/elm/Types/ServerSetup.elm
+++ b/frontend/src/elm/Types/ServerSetup.elm
@@ -13,6 +13,7 @@ module Types.ServerSetup exposing
 import Types.Config.FacetAspectConfig exposing (FacetAspectConfig)
 import Types.Config.FtsAspectConfig exposing (FtsAspectConfig)
 import Types.Config.MasksConfig exposing (MasksPurposeServerConfig)
+import Types.Id exposing (FolderId)
 import Types.Selection as Selection
 
 
@@ -24,7 +25,8 @@ type alias ServerSetup =
 
 {-| -}
 type alias ServerConfig =
-    { defaultPageSize : Maybe Int
+    { toplevelFolders : Maybe (List FolderId)
+    , defaultPageSize : Maybe Int
     , defaultSorting : Maybe Selection.Sorting
     , numberOfFacetValues : Maybe Int
     , staticFtsAspects : Maybe (List FtsAspectConfig)

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -95,7 +95,7 @@ init config =
 needs : Context -> Model -> Cache.Needs
 needs context model =
     Types.Needs.batch
-        [ Types.Needs.atomic Cache.NeedRootFolderIds
+        [ Types.Needs.atomic (Cache.NeedFolders context.config.toplevelFolders)
         , UI.Tree.needs
             { config = context.config
             , cache = context.cache

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -95,7 +95,7 @@ init config =
 needs : Context -> Model -> Cache.Needs
 needs context model =
     Types.Needs.batch
-        [ Types.Needs.atomic (Cache.NeedFolders context.config.toplevelFolders)
+        [ Types.Needs.atomic (Cache.NeedFolders context.config.toplevelFolderIds)
         , UI.Tree.needs
             { config = context.config
             , cache = context.cache

--- a/frontend/src/elm/UI/Article.elm
+++ b/frontend/src/elm/UI/Article.elm
@@ -166,7 +166,7 @@ folderCountsForQuery context =
             Nothing
 
         ListingPresentation selection window ->
-            Cache.Derive.folderCountsOnPath context.cache selection
+            Cache.Derive.folderCountsOnPath context.config context.cache selection
                 |> Just
 
 
@@ -262,7 +262,7 @@ viewBreadcrumbs : Context -> Maybe FolderId -> Html msg
 viewBreadcrumbs context maybeFolderId =
     maybeFolderId
         |> Maybe.andThen
-            (Cache.Derive.getPath context.cache
+            (Cache.Derive.getPath context.config context.cache
                 >> RemoteData.toMaybe
             )
         |> UI.Widgets.Breadcrumbs.view context

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -25,7 +25,7 @@ import Api.Mutations
 import Cache exposing (Cache)
 import Entities.Document as Document exposing (Document)
 import Entities.Markup
-import Entities.Residence exposing (Residence)
+import Entities.Residence as Residence exposing (Residence)
 import Html exposing (Html)
 import Html.Attributes
 import Html.Events
@@ -291,7 +291,7 @@ viewResidence context residence =
                             |> UI.Widgets.Breadcrumbs.view context
                         ]
                 )
-                residence
+                (Residence.limitToToplevelFolders context.config residence)
         ]
 
 

--- a/frontend/src/elm/UI/Article/Generic.elm
+++ b/frontend/src/elm/UI/Article/Generic.elm
@@ -70,14 +70,16 @@ view context model =
             -- Find the reason why we have a GenericPresentation
             case context.genericParameters of
                 Nothing ->
-                    Cache.Derive.getFirstRootFolder context.config context.cache
-                        |> RemoteData.map
-                            (Localization.string context.config
-                                { en = "Going to show the root folder"
-                                , de = "Laden des Startverzeichnisses"
-                                }
-                                |> always
-                            )
+                    (List.length context.config.toplevelFolderIds < 2)
+                        |> Utils.ifElse
+                            { en = "Going to show the top folder"
+                            , de = "Laden des Startverzeichnisses"
+                            }
+                            { en = "Going to show the top folders"
+                            , de = "Laden der Startverzeichnisse"
+                            }
+                        |> Localization.string context.config
+                        |> Success
 
                 Just ( nodeId, Nothing ) ->
                     Cache.Derive.getNodeType context.cache nodeId

--- a/frontend/src/elm/UI/Article/Generic.elm
+++ b/frontend/src/elm/UI/Article/Generic.elm
@@ -70,7 +70,7 @@ view context model =
             -- Find the reason why we have a GenericPresentation
             case context.genericParameters of
                 Nothing ->
-                    Cache.Derive.getRootFolder context.config context.cache
+                    Cache.Derive.getFirstRootFolder context.config context.cache
                         |> RemoteData.map
                             (Localization.string context.config
                                 { en = "Going to show the root folder"

--- a/frontend/src/elm/UI/Article/Generic.elm
+++ b/frontend/src/elm/UI/Article/Generic.elm
@@ -70,7 +70,7 @@ view context model =
             -- Find the reason why we have a GenericPresentation
             case context.genericParameters of
                 Nothing ->
-                    Cache.Derive.getRootFolder context.cache
+                    Cache.Derive.getRootFolder context.config context.cache
                         |> RemoteData.map
                             (Localization.string context.config
                                 { en = "Going to show the root folder"

--- a/frontend/src/elm/UI/Article/Generic.elm
+++ b/frontend/src/elm/UI/Article/Generic.elm
@@ -70,14 +70,22 @@ view context model =
             -- Find the reason why we have a GenericPresentation
             case context.genericParameters of
                 Nothing ->
-                    (List.length context.config.toplevelFolderIds < 2)
-                        |> Utils.ifElse
+                    (case List.length context.config.toplevelFolderIds of
+                        0 ->
+                            { en = "There are no known top folders."
+                            , de = "Es sind keine Startverzeichnisse bekannt."
+                            }
+
+                        1 ->
                             { en = "Going to show the top folder"
                             , de = "Laden des Startverzeichnisses"
                             }
+
+                        _ ->
                             { en = "Going to show the top folders"
                             , de = "Laden der Startverzeichnisse"
                             }
+                    )
                         |> Localization.string context.config
                         |> Success
 

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -318,7 +318,7 @@ getSearchFieldPlaceholder : Context -> String
 getSearchFieldPlaceholder context =
     Types.Presentation.getFolderId context.cache context.presentation
         |> Maybe.Extra.orElse
-            (Cache.Derive.getRootFolderId context.config context.cache)
+            (context.config.toplevelFolderIds |> List.head)
         |> Maybe.andThen
             (\folderId ->
                 Cache.get context.cache.folders folderId

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -23,7 +23,6 @@ module UI.Controls exposing
 -}
 
 import Cache exposing (Cache)
-import Cache.Derive
 import Html exposing (Html)
 import Html.Attributes
 import Html.Events

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -318,7 +318,7 @@ getSearchFieldPlaceholder : Context -> String
 getSearchFieldPlaceholder context =
     Types.Presentation.getFolderId context.cache context.presentation
         |> Maybe.Extra.orElse
-            (Cache.Derive.getRootFolderId context.cache)
+            (Cache.Derive.getRootFolderId context.config context.cache)
         |> Maybe.andThen
             (\folderId ->
                 Cache.get context.cache.folders folderId

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -80,7 +80,7 @@ initialModel =
 needs : Context -> Model -> Cache.Needs
 needs context model =
     getPresentationFolderId context
-        |> Cache.Derive.getPathAsFarAsCached context.cache
+        |> Cache.Derive.getPathAsFarAsCached context.config context.cache
         |> Cache.NeedSubfolders
         |> Types.Needs.atomic
 
@@ -175,7 +175,7 @@ viewFolderTree context model maybeFolderCounts id =
                     expanded =
                         Folder.isRoot folder
                             || (model.collapsedPresentationFolder /= Just id)
-                            && Cache.Derive.isOnPath context.cache id presentationFolderId
+                            && Cache.Derive.isOnPath context.config context.cache id presentationFolderId
                 in
                 [ Html.div
                     [ Html.Events.onClick (Select id) ]

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -128,7 +128,7 @@ view context model maybeFolderCounts =
             context
             model
             maybeFolderCounts
-            (RemoteData.Success context.config.toplevelFolders)
+            (RemoteData.Success context.config.toplevelFolderIds)
         ]
 
 

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -128,7 +128,7 @@ view context model maybeFolderCounts =
             context
             model
             maybeFolderCounts
-            context.cache.rootFolderIds
+            (RemoteData.Success context.config.toplevelFolders)
         ]
 
 


### PR DESCRIPTION
Applications (like "Hochschulbibliographie") need a means to configure a set of toplevel folders, which may represent only a selection of the whole database.

Up to now we had defined a global root node (as the single node that has the type `collections`), which was accessible in the API as `allFolders(isRoot: true)`. This is not sufficient to configure an application as desired.

New approach:
- The server now has a table `config.application` to define the set of toplevel folders that an application want to expose.
- We extend the server-provided configuration by a field `toplevelFolderIds`.
- The client adopts this configuration field.
- The client cache no longer manages the value `toplevelFolders`. `NeedRootFolderIds` is dropped and `NeedFolders` is used instead.
- When querying the residence of a document the server currently still returns the full lineages up to the global root node. The client has to limit the shown residence to the folders that are accessible from one of the toplvel folders.
