### PR TITLE
Incremental loading of listing results with "Show More" button

### DIFF
--- a/backend/src/sql/api-setup.sql
+++ b/backend/src/sql/api-setup.sql
@@ -32,6 +32,7 @@ create type api.masks_purpose_config as
 create type api.setup_config as
     ( toplevel_folders int4[]
     , default_limit integer
+    , max_limit integer
     , default_sorting api.fts_sorting
     , number_of_facet_values integer
     , static_fts_aspects api.fts_aspect_config[]
@@ -67,6 +68,7 @@ create or replace function api.setup_config
             where name = 'hsb'
         ) as toplevel_folders,
     	10 as default_limit,
+    	1000 as max_limit,
     	'by_rank'::api.fts_sorting as default_sorting,
         20 as number_of_facet_values,
         (select array(

--- a/backend/src/sql/api-setup.sql
+++ b/backend/src/sql/api-setup.sql
@@ -31,7 +31,7 @@ create type api.masks_purpose_config as
 
 create type api.setup_config as
     ( toplevel_folders int4[]
-    , default_page_size integer
+    , default_limit integer
     , default_sorting api.fts_sorting
     , number_of_facet_values integer
     , static_fts_aspects api.fts_aspect_config[]
@@ -66,7 +66,7 @@ create or replace function api.setup_config
             from config.application
             where name = 'hsb'
         ) as toplevel_folders,
-    	10 as default_page_size,
+    	10 as default_limit,
     	'by_rank'::api.fts_sorting as default_sorting,
         20 as number_of_facet_values,
         (select array(

--- a/frontend/elm-application.json
+++ b/frontend/elm-application.json
@@ -20,6 +20,7 @@
         "Entities.GenericNode",
         "Entities.Markup.Parser",
         "Entities.Markup",
+        "Entities.PageSequence",
         "Entities.Residence",
         "Main",
         "Pagination.Offset.Page",

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -200,6 +200,9 @@ button.filter-button, .filter-inputs {
 .attribute .highlight {
   color: red;
 }
+.no-more-results {
+  font-style: italic;
+}
 .folder-list {
   list-style-type: none;
   padding-left: 0;

--- a/frontend/src/elm/Api/Queries.elm
+++ b/frontend/src/elm/Api/Queries.elm
@@ -97,6 +97,8 @@ serverSetup =
                         |> SelectionSet.with
                             Mediatum.Object.SetupConfig.defaultLimit
                         |> SelectionSet.with
+                            Mediatum.Object.SetupConfig.maxLimit
+                        |> SelectionSet.with
                             (Mediatum.Object.SetupConfig.defaultSorting
                                 |> SelectionSet.map
                                     (Maybe.map

--- a/frontend/src/elm/Api/Queries.elm
+++ b/frontend/src/elm/Api/Queries.elm
@@ -95,7 +95,7 @@ serverSetup =
                                 |> SelectionSet.map (Maybe.map (List.map Id.fromInt))
                             )
                         |> SelectionSet.with
-                            Mediatum.Object.SetupConfig.defaultPageSize
+                            Mediatum.Object.SetupConfig.defaultLimit
                         |> SelectionSet.with
                             (Mediatum.Object.SetupConfig.defaultSorting
                                 |> SelectionSet.map
@@ -480,10 +480,10 @@ authorSearch :
     -> FolderId
     -> String
     -> SelectionSet (Pagination.Relay.Page.Page Document) Graphql.Operation.RootQuery
-authorSearch maskName pageSize referencePage paginationPosition folderId searchString =
+authorSearch maskName limit referencePage paginationPosition folderId searchString =
     Mediatum.Query.authorSearch
         (Pagination.Relay.Pagination.paginationArguments
-            pageSize
+            limit
             referencePage
             paginationPosition
         )

--- a/frontend/src/elm/App.elm
+++ b/frontend/src/elm/App.elm
@@ -187,6 +187,7 @@ update context msg model =
                     let
                         route =
                             Navigation.alterRoute
+                                context.config
                                 model1.cache
                                 navigation
                                 model1.route

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -51,6 +51,7 @@ import Entities.DocumentResults exposing (DocumentsPage)
 import Entities.Folder exposing (Folder)
 import Entities.FolderCounts exposing (FolderCounts)
 import Entities.GenericNode as GenericNode exposing (GenericNode)
+import Entities.PageSequence as PageSequence exposing (PageSequence)
 import Entities.Residence as Residence exposing (Residence)
 import List.Nonempty
 import Ordering exposing (Ordering)

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -178,7 +178,7 @@ targetNeeds config needs cache =
 -}
 statusOfNeed : Config -> Cache -> Need -> Needs.Status
 statusOfNeed config cache need =
-    case need |> Debug.log "statusOfNeed" of
+    case need of
         NeedFolders folderIds ->
             Needs.statusFromListOfRemoteData
                 (List.map (get cache.folders) folderIds)
@@ -217,7 +217,7 @@ Also mark the corresponding cache entries as `RemoteData.Loading`.
 -}
 requestNeed : Config -> Need -> Cache -> ( Cache, Cmd Msg )
 requestNeed config need cache =
-    case need |> Debug.log "requestNeed" of
+    case need of
         NeedFolders folderIds ->
             let
                 unknownFolderIds =
@@ -465,7 +465,7 @@ update config msg cache =
                 | documentsPages =
                     Sort.Dict.insert
                         ( maskName, selection )
-                        (PageSequence.updatePage
+                        (PageSequence.updatePageResult
                             window
                             (RemoteData.fromResult result)
                             (getDocumentsPages cache ( maskName, selection ))

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -3,8 +3,7 @@ module Cache exposing
     , Need(..), Needs, targetNeeds
     , updateWithModifiedDocument
     , Msg(..), init, update
-    , orderingSelectionWindow, orderingSelectionFacets, orderingMaskDocumentIdFromSearch
-    , orderingMaskSelection
+    , orderingSelectionWindow, orderingMaskSelection, orderingSelectionFacets, orderingMaskDocumentIdFromSearch
     )
 
 {-| Manage fetching and caching of all API data.
@@ -41,7 +40,7 @@ So the consuming modules will have to deal with the possible states a `RemoteDat
 
 # Internal functions exposed for testing only
 
-@docs orderingSelectionWindow, orderingMaskSelectionWindow, orderingSelectionFacets, orderingMaskDocumentIdFromSearch
+@docs orderingSelectionWindow, orderingMaskSelection, orderingSelectionFacets, orderingMaskDocumentIdFromSearch
 
 -}
 
@@ -643,7 +642,7 @@ orderingSelectionWindow =
             (Ordering.byFieldWith Types.orderingWindow Tuple.second)
 
 
-{-| Ordering on the tuple type `( String, Selection, Window )`
+{-| Ordering on the tuple type `( String, Selection )`
 -}
 orderingMaskSelection : Ordering ( String, Selection )
 orderingMaskSelection =

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -1,8 +1,7 @@
 module Cache exposing
-    ( Cache, ApiData, get
+    ( Cache, get
     , Need(..), Needs, targetNeeds
     , updateWithModifiedDocument
-    , ApiError, apiErrorToString
     , Msg(..), init, update
     , orderingSelectionWindow, orderingMaskSelectionWindow, orderingSelectionFacets, orderingMaskDocumentIdFromSearch
     )
@@ -21,7 +20,7 @@ So the consuming modules will have to deal with the possible states a `RemoteDat
 
 # Cached Data
 
-@docs Cache, ApiData, get
+@docs Cache, get
 
 
 # Declaring required data
@@ -32,11 +31,6 @@ So the consuming modules will have to deal with the possible states a `RemoteDat
 # Modifying data locally (preliminary)
 
 @docs updateWithModifiedDocument
-
-
-# Error handling
-
-@docs ApiError, apiErrorToString
 
 
 # Elm architecture standard functions
@@ -63,6 +57,7 @@ import Ordering exposing (Ordering)
 import RemoteData exposing (RemoteData(..))
 import Sort.Dict
 import Types exposing (DocumentIdFromSearch, NodeType(..), Window)
+import Types.ApiData exposing (ApiData)
 import Types.Aspect as Aspect exposing (Aspect)
 import Types.Config exposing (Config)
 import Types.FacetValue exposing (FacetsValues)
@@ -71,23 +66,6 @@ import Types.Needs as Needs
 import Types.Selection as Selection exposing (Selection)
 import Utils
 import Utils.List
-
-
-{-| A specialization of [`RemoteData e a`](/packages/krisajenkins/remotedata/6.0.1/RemoteData#RemoteData)
-where the error type `e` is defined by `ApiError`.
-
-Any `RemoteData` used in this module uses this error type and is therefore an `ApiData`.
-
--}
-type alias ApiData a =
-    RemoteData ApiError a
-
-
-{-| The type of errors that may be reported in an `ApiData.Failure`.
-It's the same as `Api.Error`.
--}
-type alias ApiError =
-    Api.Error
 
 
 {-| Represents all known data (in whatever state it may be: `Loading`, `Failure` or `Success`).
@@ -128,13 +106,6 @@ type Need
 -}
 type alias Needs =
     Needs.Needs Need
-
-
-{-| Describe an `ApiError` as text (aimed for debugging)
--}
-apiErrorToString : ApiError -> String
-apiErrorToString apiError =
-    Api.errorToString apiError
 
 
 {-| Initial cache model without any entry

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -98,7 +98,7 @@ type Need
     | NeedSubfolders (List FolderId)
     | NeedGenericNode String NodeId
     | NeedDocumentFromSearch String DocumentIdFromSearch
-    | NeedDocumentsPage String Selection Window
+    | NeedDocumentsPage String Selection Int
     | NeedFolderCounts Selection
     | NeedFacets Selection (List Aspect)
 
@@ -194,9 +194,9 @@ statusOfNeed config cache need =
             get cache.documents ( maskName, documentIdFromSearch )
                 |> Needs.statusFromRemoteData
 
-        NeedDocumentsPage maskName selection window ->
+        NeedDocumentsPage maskName selection limit ->
             getDocumentsPages cache ( maskName, selection )
-                |> PageSequence.statusOfNeededWindow window
+                |> PageSequence.statusOfNeededWindow limit
 
         NeedFolderCounts selection ->
             get cache.folderCounts selection
@@ -301,11 +301,11 @@ requestNeed config need cache =
                 (Api.Queries.documentDetails maskName documentIdFromSearch needResidence)
             )
 
-        NeedDocumentsPage maskName selection window ->
+        NeedDocumentsPage maskName selection limit ->
             let
                 ( maybeIndexAndNeededWindow, newPageSequence ) =
                     PageSequence.requestWindow
-                        window
+                        limit
                         (getDocumentsPages cache ( maskName, selection ))
             in
             ( { cache

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -144,7 +144,7 @@ If the given key is not yet present in the table return `RemoteData.NotAsked`.
 getDocumentsPages : Cache -> ( String, Selection ) -> PageSequence
 getDocumentsPages cache key =
     Sort.Dict.get key cache.documentsPages
-        |> Maybe.withDefault []
+        |> Maybe.withDefault PageSequence.init
 
 
 {-| The messages that the `update` function may process in response to an executed `Cmd`.

--- a/frontend/src/elm/Cache/Derive.elm
+++ b/frontend/src/elm/Cache/Derive.elm
@@ -42,12 +42,13 @@ module Cache.Derive exposing
 
 -}
 
-import Cache exposing (ApiData, Cache)
+import Cache exposing (Cache)
 import Entities.FolderCounts as FolderCounts exposing (FolderCounts)
 import Maybe.Extra
 import RemoteData exposing (RemoteData(..))
 import Sort.Dict
 import Types exposing (FolderDisplay(..), NodeType(..))
+import Types.ApiData as ApiData exposing (ApiData, ApiError)
 import Types.Config exposing (Config)
 import Types.Id as Id exposing (DocumentId, FolderId, NodeId)
 import Types.Selection exposing (Selection)
@@ -66,7 +67,7 @@ type alias DerivedData a =
 {-| An error on getting derived data may be either an ApiError or some logical error within the base data.
 -}
 type Error
-    = CacheApiError Cache.ApiError
+    = CacheApiError ApiError
     | CacheDerivationError String
 
 
@@ -75,7 +76,7 @@ errorToString : Error -> String
 errorToString error =
     case error of
         CacheApiError apiError ->
-            Cache.apiErrorToString apiError
+            ApiData.apiErrorToString apiError
 
         CacheDerivationError str ->
             str

--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -1,8 +1,12 @@
-module Constants exposing (apiUrl, graphqlOperationNamePrefix)
+module Constants exposing
+    ( apiUrl, graphqlOperationNamePrefix
+    , incrementLimitOnShowMore
+    )
 
 {-| Configurable values
 
 @docs apiUrl, graphqlOperationNamePrefix
+@docs incrementLimitOnShowMore
 
 -}
 
@@ -22,3 +26,19 @@ For operation names see: <https://graphql.org/learn/queries/#operation-name>
 graphqlOperationNamePrefix : String
 graphqlOperationNamePrefix =
     "mediatumView_"
+
+
+{-| -}
+incrementLimitOnShowMore : Int -> Int
+incrementLimitOnShowMore limit =
+    if limit <= 10 then
+        20
+
+    else if limit <= 30 then
+        50
+
+    else if limit <= 70 then
+        100
+
+    else
+        ((limit + 149) // 100) * 100

--- a/frontend/src/elm/Entities/DocumentResults.elm
+++ b/frontend/src/elm/Entities/DocumentResults.elm
@@ -29,7 +29,7 @@ type alias DocumentResult =
     }
 
 
-{-| A [page](Types#WindowPage) of document results
+{-| A [page](Types#WindowPage) of document results as received from the API
 -}
 type alias DocumentsPage =
     Types.WindowPage DocumentResult

--- a/frontend/src/elm/Entities/PageSequence.elm
+++ b/frontend/src/elm/Entities/PageSequence.elm
@@ -1,12 +1,7 @@
-module Entities.PageSequence exposing (PageSequence, init, requestWindow, statusOfNeededWindow, toList, updatePageResult)
-
-import Entities.DocumentResults exposing (DocumentsPage)
-import List.Extra
-import RemoteData exposing (RemoteData(..))
-import Types exposing (Window)
-import Types.ApiData exposing (ApiData)
-import Types.Needs as Needs exposing (Status(..))
-
+module Entities.PageSequence exposing
+    ( PageSequence, init, toList
+    , statusOfNeededWindow, requestWindow, updatePageResult
+    )
 
 {-| Listings of documents may get queryied in several consecutive pages,
 e.g. by a UI button to load more results.
@@ -18,8 +13,19 @@ The segmentation of the listing into pages reflects the history of requests to p
 
 @docs PageSequence, init, toList
 
-@docs statusOfNeededWindow, requestWindow, updatePage
+@docs statusOfNeededWindow, requestWindow, updatePageResult
 
+-}
+
+import Entities.DocumentResults exposing (DocumentsPage)
+import List.Extra
+import RemoteData exposing (RemoteData(..))
+import Types exposing (Window)
+import Types.ApiData exposing (ApiData)
+import Types.Needs as Needs exposing (Status(..))
+
+
+{-| The type `PageSequence` represents a sequence of pages that are stiched together for a listing
 -}
 type PageSequence
     = PageSequence PageSequenceIntern
@@ -29,16 +35,22 @@ type alias PageSequenceIntern =
     List ( Int, ApiData DocumentsPage )
 
 
+{-| Return an empty page sequence
+-}
 init : PageSequence
 init =
     PageSequence []
 
 
+{-| Return the list of pages, given as `ApiData DocumentsPage`
+-}
 toList : PageSequence -> List (ApiData DocumentsPage)
 toList (PageSequence pageSequence) =
     List.map Tuple.second pageSequence
 
 
+{-| Determine if a given page sequence fullfills the needs to show a given window of a listing
+-}
 statusOfNeededWindow : Window -> PageSequence -> Needs.Status
 statusOfNeededWindow window (PageSequence pageSequence) =
     let
@@ -68,6 +80,12 @@ statusOfNeededWindow window (PageSequence pageSequence) =
     step 0 pageSequence
 
 
+{-| Possibly add a new page (with state `Loading`) to the page sequence,
+so that the whole given window is covered by the sequence.
+
+Also returns the page index and the window that needs to be queried in addition.
+
+-}
 requestWindow : Window -> PageSequence -> ( Maybe ( Int, Window ), PageSequence )
 requestWindow window (PageSequence pageSequence) =
     let
@@ -111,6 +129,8 @@ requestWindow window (PageSequence pageSequence) =
         |> Tuple.mapSecond PageSequence
 
 
+{-| Update a page (most likely the last one) of the sequence after recieving the query's result.
+-}
 updatePageResult : Int -> Window -> ApiData DocumentsPage -> PageSequence -> PageSequence
 updatePageResult pageIndex window apiData (PageSequence pageSequence) =
     List.Extra.setAt

--- a/frontend/src/elm/Entities/PageSequence.elm
+++ b/frontend/src/elm/Entities/PageSequence.elm
@@ -73,6 +73,7 @@ presentationSegments limit (PageSequence array complete) =
         array
 
 
+{-| -}
 canShowMore : Int -> PageSequence -> Bool
 canShowMore limit (PageSequence array complete) =
     not complete || limit < numberOfResults array

--- a/frontend/src/elm/Entities/PageSequence.elm
+++ b/frontend/src/elm/Entities/PageSequence.elm
@@ -1,6 +1,6 @@
 module Entities.PageSequence exposing
     ( PageSequence, init
-    , PresentationSegments, presentationSegments
+    , PresentationSegments, presentationSegments, canShowMore
     , statusOfNeededWindow, requestWindow, updatePageResult
     )
 
@@ -12,7 +12,7 @@ The type `PageSequence` represents such a sequence of pages as it is stored in t
 The segmentation of the listing into pages reflects the history of requests to prolong the listing.
 
 @docs PageSequence, init
-@docs PresentationSegments, presentationSegments
+@docs PresentationSegments, presentationSegments, canShowMore
 
 @docs statusOfNeededWindow, requestWindow, updatePageResult
 
@@ -71,6 +71,11 @@ presentationSegments limit (PageSequence array complete) =
         limit
         []
         array
+
+
+canShowMore : Int -> PageSequence -> Bool
+canShowMore limit (PageSequence array complete) =
+    not complete || limit < numberOfResults array
 
 
 {-| Determine if a given page sequence fulfills the needs to show a given window of a listing

--- a/frontend/src/elm/Entities/PageSequence.elm
+++ b/frontend/src/elm/Entities/PageSequence.elm
@@ -1,0 +1,17 @@
+module Entities.PageSequence exposing (PageSequence)
+
+import Entities.DocumentResults exposing (DocumentsPage)
+import Types.ApiData exposing (ApiData)
+
+
+{-| Listings of documents may get queryied in several consecutive pages,
+e.g. by a UI button to load more results.
+
+The type `PageSequence` represents such a sequence of pages
+as it is managed by the cache.
+
+@docs PageSequence
+
+-}
+type alias PageSequence =
+    List ( Int, ApiData DocumentsPage )

--- a/frontend/src/elm/Entities/PageSequence.elm
+++ b/frontend/src/elm/Entities/PageSequence.elm
@@ -1,7 +1,10 @@
-module Entities.PageSequence exposing (PageSequence)
+module Entities.PageSequence exposing (PageSequence, requestWindow, statusOfNeededWindow, updatePage)
 
 import Entities.DocumentResults exposing (DocumentsPage)
+import RemoteData exposing (RemoteData(..))
+import Types exposing (Window)
 import Types.ApiData exposing (ApiData)
+import Types.Needs as Needs exposing (Status(..))
 
 
 {-| Listings of documents may get queryied in several consecutive pages,
@@ -11,7 +14,166 @@ The type `PageSequence` represents such a sequence of pages
 as it is managed by the cache.
 
 @docs PageSequence
+@docs statusOfNeededWindow, requestWindow, updatePage
 
 -}
 type alias PageSequence =
     List ( Int, ApiData DocumentsPage )
+
+
+statusOfNeededWindow_1 : Window -> PageSequence -> Needs.Status
+statusOfNeededWindow_1 window pageSequence =
+    let
+        neededLength =
+            window.offset + window.limit
+    in
+    pageSequence
+        |> List.foldl
+            (\( elementLength, elementApiData ) ( accuLength, accuStatus ) ->
+                ( accuLength + elementLength
+                , if neededLength < accuLength then
+                    accuStatus
+
+                  else
+                    Needs.statusPlus
+                        accuStatus
+                        (Needs.statusFromRemoteData elementApiData)
+                )
+            )
+            ( 0, Needs.Fulfilled )
+        |> Tuple.second
+        |> (\res ->
+                let
+                    _ =
+                        Debug.log "statusOfNeededWindow"
+                            { window = window, pageSequence = pageSequence, res = res }
+                in
+                res
+           )
+
+
+statusOfNeededWindow : Window -> PageSequence -> Needs.Status
+statusOfNeededWindow window pageSequence =
+    let
+        neededLength =
+            window.offset + window.limit
+
+        step : Int -> PageSequence -> Needs.Status
+        step length sequence =
+            case sequence of
+                [] ->
+                    if neededLength > length then
+                        NotRequested
+
+                    else
+                        Fulfilled
+
+                (( elementLength, elementApiData ) as element) :: tail ->
+                    Needs.statusPlus
+                        (if neededLength > length then
+                            Needs.statusFromRemoteData elementApiData
+
+                         else
+                            Fulfilled
+                        )
+                        (step (length + elementLength) tail)
+
+        requestWithExistingLength length =
+            if neededLength > length then
+                ( Just { offset = length, limit = neededLength - length }
+                , [ ( neededLength - length
+                    , Loading
+                    )
+                  ]
+                )
+
+            else
+                ( Nothing
+                , []
+                )
+    in
+    step 0 pageSequence
+        |> (\res ->
+                let
+                    _ =
+                        Debug.log "statusOfNeededWindow"
+                            { window = window, pageSequence = pageSequence, res = res }
+                in
+                res
+           )
+
+
+requestWindow : Window -> PageSequence -> ( Maybe Window, PageSequence )
+requestWindow window pageSequence =
+    let
+        neededLength =
+            window.offset + window.limit
+
+        step : Int -> PageSequence -> ( Maybe Window, PageSequence )
+        step length sequence =
+            case sequence of
+                [] ->
+                    requestWithExistingLength length
+
+                (( elementLength, elementApiData ) as element) :: tail ->
+                    if elementApiData == NotAsked then
+                        requestWithExistingLength length
+
+                    else
+                        let
+                            ( tailMaybeWindow, tailPageSequence ) =
+                                step (length + elementLength) tail
+                        in
+                        ( tailMaybeWindow
+                        , element :: tailPageSequence
+                        )
+
+        requestWithExistingLength length =
+            if neededLength > length then
+                ( Just { offset = length, limit = neededLength - length }
+                , [ ( neededLength - length
+                    , Loading
+                    )
+                  ]
+                )
+
+            else
+                ( Nothing
+                , []
+                )
+    in
+    step 0 pageSequence
+
+
+updatePage : Window -> ApiData DocumentsPage -> PageSequence -> PageSequence
+updatePage window apiData pageSequence =
+    let
+        step : Int -> PageSequence -> PageSequence
+        step length sequence =
+            if length == window.offset then
+                [ ( window.limit, apiData ) ]
+
+            else if length < window.offset then
+                case sequence of
+                    [] ->
+                        -- Should never happen
+                        [ ( window.offset - length, NotAsked )
+                        , ( window.limit, apiData )
+                        ]
+
+                    (( elementLength, _ ) as element) :: tail ->
+                        element :: step (length + elementLength) tail
+
+            else
+                -- Should never happen
+                pageSequence
+    in
+    step 0 pageSequence
+        |> (\res ->
+                let
+                    _ =
+                        Debug.log "updatePage"
+                            { window = window, apiData = apiData, pageSequence = pageSequence, res = res }
+                in
+                res
+           )

--- a/frontend/src/elm/Entities/PageSequence.elm
+++ b/frontend/src/elm/Entities/PageSequence.elm
@@ -49,7 +49,7 @@ toList (PageSequence pageSequence) =
     List.map Tuple.second pageSequence
 
 
-{-| Determine if a given page sequence fullfills the needs to show a given window of a listing
+{-| Determine if a given page sequence fulfills the needs to show a given window of a listing
 -}
 statusOfNeededWindow : Window -> PageSequence -> Needs.Status
 statusOfNeededWindow window (PageSequence pageSequence) =

--- a/frontend/src/elm/Types.elm
+++ b/frontend/src/elm/Types.elm
@@ -2,9 +2,9 @@ module Types exposing
     ( FolderDisplay(..)
     , NodeType(..)
     , Window
-    , WindowPage, sectionOfWindowPage
     , DocumentIdFromSearch
     , orderingWindow, orderingDocumentIdFromSearch
+    , WindowPage
     )
 
 {-| Some general types used throughout the application.
@@ -16,14 +16,13 @@ Note that certain other types, which are entities representing query results, ar
 @docs FolderDisplay
 @docs NodeType
 @docs Window
-@docs WindowPage, sectionOfWindowPage
+@docs WindowPagesectionOfWindowPage
 @docs DocumentIdFromSearch
 
 @docs orderingWindow, orderingDocumentIdFromSearch
 
 -}
 
-import Basics.Extra
 import Ordering exposing (Ordering)
 import Types.Id as Id exposing (DocumentId)
 import Types.SearchTerm exposing (SearchTerm)
@@ -60,33 +59,6 @@ type alias WindowPage itemModel =
     { offset : Int
     , hasNextPage : Bool
     , content : List itemModel
-    }
-
-
-{-| Get a section of a WindowPage.
-
-The cuttong points of the section are defined by a Window, whose coordinates are relative to the WindowPage.
-
-The resulting WindowPage cannot exceed the original WindowPage.
-
--}
-sectionOfWindowPage : Window -> WindowPage itemModel -> WindowPage itemModel
-sectionOfWindowPage window page =
-    let
-        pageLength =
-            List.length page.content
-
-        windowOffset =
-            window.offset |> Basics.Extra.atLeast 0
-
-        windowLimit =
-            window.limit
-                |> Basics.Extra.atLeast 0
-                |> Basics.Extra.atMost (window.offset + window.limit)
-    in
-    { offset = page.offset + (windowOffset |> Basics.Extra.atMost pageLength)
-    , hasNextPage = (windowOffset + windowLimit < pageLength) || page.hasNextPage
-    , content = page.content |> List.drop windowOffset |> List.take windowLimit
     }
 
 

--- a/frontend/src/elm/Types.elm
+++ b/frontend/src/elm/Types.elm
@@ -2,7 +2,7 @@ module Types exposing
     ( FolderDisplay(..)
     , NodeType(..)
     , Window
-    , WindowPage
+    , WindowPage, sectionOfWindowPage
     , DocumentIdFromSearch
     , orderingWindow, orderingDocumentIdFromSearch
     )
@@ -16,13 +16,14 @@ Note that certain other types, which are entities representing query results, ar
 @docs FolderDisplay
 @docs NodeType
 @docs Window
-@docs WindowPage
+@docs WindowPage, sectionOfWindowPage
 @docs DocumentIdFromSearch
 
 @docs orderingWindow, orderingDocumentIdFromSearch
 
 -}
 
+import Basics.Extra
 import Ordering exposing (Ordering)
 import Types.Id as Id exposing (DocumentId)
 import Types.SearchTerm exposing (SearchTerm)
@@ -59,6 +60,33 @@ type alias WindowPage itemModel =
     { offset : Int
     , hasNextPage : Bool
     , content : List itemModel
+    }
+
+
+{-| Get a section of a WindowPage.
+
+The cuttong points of the section are defined by a Window, whose coordinates are relative to the WindowPage.
+
+The resulting WindowPage cannot exceed the original WindowPage.
+
+-}
+sectionOfWindowPage : Window -> WindowPage itemModel -> WindowPage itemModel
+sectionOfWindowPage window page =
+    let
+        pageLength =
+            List.length page.content
+
+        windowOffset =
+            window.offset |> Basics.Extra.atLeast 0
+
+        windowLimit =
+            window.limit
+                |> Basics.Extra.atLeast 0
+                |> Basics.Extra.atMost (window.offset + window.limit)
+    in
+    { offset = page.offset + (windowOffset |> Basics.Extra.atMost pageLength)
+    , hasNextPage = (windowOffset + windowLimit < pageLength) || page.hasNextPage
+    , content = page.content |> List.drop windowOffset |> List.take windowLimit
     }
 
 

--- a/frontend/src/elm/Types.elm
+++ b/frontend/src/elm/Types.elm
@@ -2,9 +2,9 @@ module Types exposing
     ( FolderDisplay(..)
     , NodeType(..)
     , Window
+    , WindowPage
     , DocumentIdFromSearch
     , orderingWindow, orderingDocumentIdFromSearch
-    , WindowPage
     )
 
 {-| Some general types used throughout the application.
@@ -16,7 +16,7 @@ Note that certain other types, which are entities representing query results, ar
 @docs FolderDisplay
 @docs NodeType
 @docs Window
-@docs WindowPagesectionOfWindowPage
+@docs WindowPage
 @docs DocumentIdFromSearch
 
 @docs orderingWindow, orderingDocumentIdFromSearch

--- a/frontend/src/elm/Types/ApiData.elm
+++ b/frontend/src/elm/Types/ApiData.elm
@@ -1,0 +1,42 @@
+module Types.ApiData exposing
+    ( ApiData
+    , ApiError, apiErrorToString
+    )
+
+{-| A specialization of [`RemoteData e a`](/packages/krisajenkins/remotedata/6.0.1/RemoteData#RemoteData)
+where the error type `e` is defined by `ApiError`.
+
+Any `RemoteData` used in this module uses this error type and is therefore an `ApiData`.
+
+
+# Data
+
+@docs ApiData
+
+
+# Error handling
+
+@docs ApiError, apiErrorToString
+
+-}
+
+import Api
+import RemoteData exposing (RemoteData)
+
+
+type alias ApiData a =
+    RemoteData ApiError a
+
+
+{-| The type of errors that may be reported in an `ApiData.Failure`.
+It's the same as `Api.Error`.
+-}
+type alias ApiError =
+    Api.Error
+
+
+{-| Describe an `ApiError` as text (aimed for debugging)
+-}
+apiErrorToString : ApiError -> String
+apiErrorToString apiError =
+    Api.errorToString apiError

--- a/frontend/src/elm/Types/Config.elm
+++ b/frontend/src/elm/Types/Config.elm
@@ -36,6 +36,7 @@ type alias Config =
     , serverConfigAdopted : Bool
     , toplevelFolderIds : List FolderId
     , defaultLimit : Int
+    , maxLimit : Int
     , defaultSorting : Selection.Sorting
     , numberOfFacetValues : Int
     , ftsAspects : List FtsAspectConfig
@@ -52,6 +53,7 @@ init =
     , serverConfigAdopted = False
     , toplevelFolderIds = []
     , defaultLimit = 10
+    , maxLimit = 1000
     , defaultSorting = Selection.ByRank
     , numberOfFacetValues = 20
     , ftsAspects = []
@@ -83,6 +85,8 @@ updateFromServerSetup serverSetup config =
             serverSetup.config.toplevelFolderIds |> Maybe.withDefault config.toplevelFolderIds
         , defaultLimit =
             serverSetup.config.defaultLimit |> Maybe.withDefault config.defaultLimit
+        , maxLimit =
+            serverSetup.config.maxLimit |> Maybe.withDefault config.maxLimit
         , defaultSorting =
             serverSetup.config.defaultSorting |> Maybe.withDefault config.defaultSorting
         , numberOfFacetValues =

--- a/frontend/src/elm/Types/Config.elm
+++ b/frontend/src/elm/Types/Config.elm
@@ -35,7 +35,7 @@ type alias Config =
     { uiLanguage : Language
     , serverConfigAdopted : Bool
     , toplevelFolderIds : List FolderId
-    , defaultPageSize : Int
+    , defaultLimit : Int
     , defaultSorting : Selection.Sorting
     , numberOfFacetValues : Int
     , ftsAspects : List FtsAspectConfig
@@ -51,7 +51,7 @@ init =
     { uiLanguage = Localization.LangEn
     , serverConfigAdopted = False
     , toplevelFolderIds = []
-    , defaultPageSize = 10
+    , defaultLimit = 10
     , defaultSorting = Selection.ByRank
     , numberOfFacetValues = 20
     , ftsAspects = []
@@ -81,8 +81,8 @@ updateFromServerSetup serverSetup config =
         | serverConfigAdopted = True
         , toplevelFolderIds =
             serverSetup.config.toplevelFolderIds |> Maybe.withDefault config.toplevelFolderIds
-        , defaultPageSize =
-            serverSetup.config.defaultPageSize |> Maybe.withDefault config.defaultPageSize
+        , defaultLimit =
+            serverSetup.config.defaultLimit |> Maybe.withDefault config.defaultLimit
         , defaultSorting =
             serverSetup.config.defaultSorting |> Maybe.withDefault config.defaultSorting
         , numberOfFacetValues =

--- a/frontend/src/elm/Types/Navigation.elm
+++ b/frontend/src/elm/Types/Navigation.elm
@@ -27,7 +27,6 @@ type Navigation
     | ShowListingWithSearchAndFtsFilter GlobalFts FtsFilters Sorting
     | ShowListingWithAddedFacetFilter Aspect String
     | ShowListingWithRemovedFacetFilter Aspect
-    | SetOffset Int
     | SetLimit Int
 
 
@@ -56,14 +55,11 @@ alterRoute cache navigation route =
                     Route.TwoIds idOne _ ->
                         Route.OneId idOne
             , parameters =
-                parametersWithOffset0
+                parameters
             }
 
         parameters =
             route.parameters
-
-        parametersWithOffset0 =
-            { parameters | offset = 0 }
     in
     case navigation of
         ListOfNavigations listOfNavigations ->
@@ -87,7 +83,7 @@ alterRoute cache navigation route =
         ShowListingWithSearchAndFtsFilter globalFts ftsFilters sorting ->
             { listingRoute
                 | parameters =
-                    { parametersWithOffset0
+                    { parameters
                         | globalFts = globalFts
                         , sorting = sorting
                         , ftsFilters = ftsFilters
@@ -97,7 +93,7 @@ alterRoute cache navigation route =
         ShowListingWithAddedFacetFilter aspect value ->
             { listingRoute
                 | parameters =
-                    { parametersWithOffset0
+                    { parameters
                         | facetFilters =
                             FilterList.insert aspect value parameters.facetFilters
                     }
@@ -106,16 +102,10 @@ alterRoute cache navigation route =
         ShowListingWithRemovedFacetFilter aspect ->
             { listingRoute
                 | parameters =
-                    { parametersWithOffset0
+                    { parameters
                         | facetFilters =
                             FilterList.remove aspect parameters.facetFilters
                     }
-            }
-
-        SetOffset offset ->
-            { route
-                | parameters =
-                    { parameters | offset = offset }
             }
 
         SetLimit limit ->

--- a/frontend/src/elm/Types/Navigation.elm
+++ b/frontend/src/elm/Types/Navigation.elm
@@ -13,6 +13,7 @@ module Types.Navigation exposing
 import Cache exposing (Cache)
 import Cache.Derive
 import Types.Aspect exposing (Aspect)
+import Types.Config exposing (Config)
 import Types.FilterList as FilterList
 import Types.Id as Id exposing (DocumentId, FolderId)
 import Types.Route as Route exposing (Route)
@@ -35,8 +36,8 @@ type Navigation
 In some cases this uses knowledge about node types from the cache.
 
 -}
-alterRoute : Cache -> Navigation -> Route -> Route
-alterRoute cache navigation route =
+alterRoute : Config -> Cache -> Navigation -> Route -> Route
+alterRoute config cache navigation route =
     let
         listingRoute =
             { path =
@@ -55,15 +56,18 @@ alterRoute cache navigation route =
                     Route.TwoIds idOne _ ->
                         Route.OneId idOne
             , parameters =
-                parameters
+                parametersWithDefaultLimit
             }
 
         parameters =
             route.parameters
+
+        parametersWithDefaultLimit =
+            { parameters | limit = config.defaultPageSize }
     in
     case navigation of
         ListOfNavigations listOfNavigations ->
-            List.foldl (alterRoute cache) route listOfNavigations
+            List.foldl (alterRoute config cache) route listOfNavigations
 
         ShowDocument folderId documentId ->
             { route

--- a/frontend/src/elm/Types/Navigation.elm
+++ b/frontend/src/elm/Types/Navigation.elm
@@ -87,7 +87,7 @@ alterRoute config cache navigation route =
         ShowListingWithSearchAndFtsFilter globalFts ftsFilters sorting ->
             { listingRoute
                 | parameters =
-                    { parameters
+                    { parametersWithDefaultLimit
                         | globalFts = globalFts
                         , sorting = sorting
                         , ftsFilters = ftsFilters
@@ -97,7 +97,7 @@ alterRoute config cache navigation route =
         ShowListingWithAddedFacetFilter aspect value ->
             { listingRoute
                 | parameters =
-                    { parameters
+                    { parametersWithDefaultLimit
                         | facetFilters =
                             FilterList.insert aspect value parameters.facetFilters
                     }
@@ -106,7 +106,7 @@ alterRoute config cache navigation route =
         ShowListingWithRemovedFacetFilter aspect ->
             { listingRoute
                 | parameters =
-                    { parameters
+                    { parametersWithDefaultLimit
                         | facetFilters =
                             FilterList.remove aspect parameters.facetFilters
                     }

--- a/frontend/src/elm/Types/Navigation.elm
+++ b/frontend/src/elm/Types/Navigation.elm
@@ -63,7 +63,7 @@ alterRoute config cache navigation route =
             route.parameters
 
         parametersWithDefaultLimit =
-            { parameters | limit = config.defaultPageSize }
+            { parameters | limit = config.defaultLimit }
     in
     case navigation of
         ListOfNavigations listOfNavigations ->

--- a/frontend/src/elm/Types/Needs.elm
+++ b/frontend/src/elm/Types/Needs.elm
@@ -131,6 +131,8 @@ type Status
     | OnGoing
 
 
+{-| Combine two Status values
+-}
 statusPlus : Status -> Status -> Status
 statusPlus statusOne statusTwo =
     if statusOne == NotRequested || statusTwo == NotRequested then

--- a/frontend/src/elm/Types/Needs.elm
+++ b/frontend/src/elm/Types/Needs.elm
@@ -2,7 +2,7 @@ module Types.Needs exposing
     ( Needs
     , none, atomic, batch, sequence
     , Status(..)
-    , statusFromRemoteData, statusFromListOfRemoteData
+    , statusFromRemoteData, statusFromListOfRemoteData, statusPlus
     , StatusOfAtomicNeed, RequestAtomicNeed, target
     , flatten
     )
@@ -22,7 +22,7 @@ The type variable `n` stands for an atomic need.
 # Status of a need
 
 @docs Status
-@docs statusFromRemoteData, statusFromListOfRemoteData
+@docs statusFromRemoteData, statusFromListOfRemoteData, statusPlus
 
 
 # Targeting needs

--- a/frontend/src/elm/Types/Presentation.elm
+++ b/frontend/src/elm/Types/Presentation.elm
@@ -33,7 +33,7 @@ import Cache exposing (Cache)
 import Cache.Derive
 import Maybe.Extra
 import RemoteData
-import Types exposing (DocumentIdFromSearch, FolderDisplay(..), NodeType(..), Window)
+import Types exposing (DocumentIdFromSearch, FolderDisplay(..), NodeType(..))
 import Types.Config exposing (Config)
 import Types.FilterList as FilterList
 import Types.Id as Id exposing (FolderId, NodeId)
@@ -46,7 +46,7 @@ type Presentation
     = GenericPresentation (Maybe ( NodeId, Maybe DocumentIdFromSearch ))
     | CollectionPresentation FolderId
     | DocumentPresentation (Maybe FolderId) DocumentIdFromSearch
-    | ListingPresentation Selection Window
+    | ListingPresentation Selection Int
 
 
 {-| -}
@@ -64,7 +64,7 @@ getFolderId cache presentation =
         CollectionPresentation folderId ->
             Just folderId
 
-        ListingPresentation selection window ->
+        ListingPresentation selection limit ->
             Just selection.scope
 
 
@@ -88,12 +88,7 @@ fromRoute config cache route =
                     , facetFilters = route.parameters.facetFilters
                     , sorting = route.parameters.sorting
                     }
-                    windowOfRoute
-
-        windowOfRoute =
-            { offset = route.parameters.offset
-            , limit = route.parameters.limit
-            }
+                    route.parameters.limit
     in
     case route.path of
         Route.NoId ->

--- a/frontend/src/elm/Types/Route.elm
+++ b/frontend/src/elm/Types/Route.elm
@@ -77,7 +77,7 @@ emptyParameters config =
     , sorting = config.defaultSorting
     , ftsFilters = Selection.initFtsFilters
     , facetFilters = Selection.initFacetFilters
-    , limit = config.defaultPageSize
+    , limit = config.defaultLimit
     }
 
 

--- a/frontend/src/elm/Types/Route.elm
+++ b/frontend/src/elm/Types/Route.elm
@@ -22,6 +22,7 @@ Parsing URLs and stringifying routes are defined in [`Types.Route.Url`](Types-Ro
 
 -}
 
+import Basics.Extra
 import Types.Config exposing (Config)
 import Types.Config.FacetAspectConfig as FacetAspect
 import Types.Config.FtsAspectConfig as FtsAspect
@@ -87,8 +88,13 @@ In particular, make sure that the aspects used for fts filters or facet filters 
 sanitize : Config -> Route -> Route
 sanitize config route =
     let
-        parameters =
+        parameters0 =
             route.parameters
+
+        parameters =
+            { parameters0
+                | limit = parameters0.limit |> Basics.Extra.atMost config.maxLimit
+            }
     in
     { path = route.path
     , parameters =

--- a/frontend/src/elm/Types/Route.elm
+++ b/frontend/src/elm/Types/Route.elm
@@ -50,7 +50,6 @@ type alias RouteParameters =
     , sorting : Sorting
     , ftsFilters : FtsFilters
     , facetFilters : FacetFilters
-    , offset : Int
     , limit : Int
     }
 
@@ -78,7 +77,6 @@ emptyParameters config =
     , sorting = config.defaultSorting
     , ftsFilters = Selection.initFtsFilters
     , facetFilters = Selection.initFacetFilters
-    , offset = 0
     , limit = config.defaultPageSize
     }
 

--- a/frontend/src/elm/Types/Route/Url.elm
+++ b/frontend/src/elm/Types/Route/Url.elm
@@ -95,13 +95,6 @@ parseQueryParameter ( name, value ) routeParameters =
                 _ ->
                     Nothing
 
-        "offset" ->
-            String.toInt value
-                |> Maybe.map
-                    (\intValue ->
-                        { routeParameters | offset = intValue }
-                    )
-
         "limit" ->
             String.toInt value
                 |> Maybe.map
@@ -196,10 +189,6 @@ toString config route =
                 (FilterList.toList route.parameters.facetFilters)
             ++ Maybe.Extra.values
                 [ buildParameterIfNotDefault
-                    (Builder.int "offset")
-                    0
-                    route.parameters.offset
-                , buildParameterIfNotDefault
                     (Builder.int "limit")
                     config.defaultPageSize
                     route.parameters.limit

--- a/frontend/src/elm/Types/Route/Url.elm
+++ b/frontend/src/elm/Types/Route/Url.elm
@@ -190,7 +190,7 @@ toString config route =
             ++ Maybe.Extra.values
                 [ buildParameterIfNotDefault
                     (Builder.int "limit")
-                    config.defaultPageSize
+                    config.defaultLimit
                     route.parameters.limit
                 ]
         )

--- a/frontend/src/elm/Types/ServerSetup.elm
+++ b/frontend/src/elm/Types/ServerSetup.elm
@@ -26,7 +26,7 @@ type alias ServerSetup =
 {-| -}
 type alias ServerConfig =
     { toplevelFolderIds : Maybe (List FolderId)
-    , defaultPageSize : Maybe Int
+    , defaultLimit : Maybe Int
     , defaultSorting : Maybe Selection.Sorting
     , numberOfFacetValues : Maybe Int
     , staticFtsAspects : Maybe (List FtsAspectConfig)

--- a/frontend/src/elm/Types/ServerSetup.elm
+++ b/frontend/src/elm/Types/ServerSetup.elm
@@ -27,6 +27,7 @@ type alias ServerSetup =
 type alias ServerConfig =
     { toplevelFolderIds : Maybe (List FolderId)
     , defaultLimit : Maybe Int
+    , maxLimit : Maybe Int
     , defaultSorting : Maybe Selection.Sorting
     , numberOfFacetValues : Maybe Int
     , staticFtsAspects : Maybe (List FtsAspectConfig)

--- a/frontend/src/elm/UI/Article.elm
+++ b/frontend/src/elm/UI/Article.elm
@@ -98,7 +98,7 @@ initialModel presentation =
         CollectionPresentation folderId ->
             { content = CollectionModel UI.Article.Collection.initialModel }
 
-        ListingPresentation selection window ->
+        ListingPresentation selection limit ->
             { content = ListingModel UI.Article.Listing.initialModel }
 
 
@@ -137,13 +137,13 @@ needs config facetAspects presentation =
         CollectionPresentation folderId ->
             Types.Needs.none
 
-        ListingPresentation selection window ->
+        ListingPresentation selection limit ->
             Types.Needs.sequence
                 (Types.Needs.atomic <|
                     Cache.NeedDocumentsPage
                         (Config.getMaskName MasksConfig.MaskForListing config)
                         selection
-                        window
+                        limit
                 )
                 (Types.Needs.batch
                     [ Types.Needs.atomic <| Cache.NeedFolderCounts selection
@@ -165,7 +165,7 @@ folderCountsForQuery context =
         CollectionPresentation folderId ->
             Nothing
 
-        ListingPresentation selection window ->
+        ListingPresentation selection limit ->
             Cache.Derive.folderCountsOnPath context.config context.cache selection
                 |> Just
 
@@ -194,14 +194,14 @@ update context msg model =
             , NoReturn
             )
 
-        ( ListingMsg subMsg, ListingModel subModel, ListingPresentation selection window ) ->
+        ( ListingMsg subMsg, ListingModel subModel, ListingPresentation selection limit ) ->
             let
                 ( subModel1, subCmd, subReturn ) =
                     UI.Article.Listing.update
                         { config = context.config
                         , cache = context.cache
                         , selection = selection
-                        , window = window
+                        , limit = limit
                         }
                         subMsg
                         subModel
@@ -289,12 +289,12 @@ viewContent context model =
                 subModel
                 |> Html.map CollectionMsg
 
-        ( ListingModel subModel, ListingPresentation selection window ) ->
+        ( ListingModel subModel, ListingPresentation selection limit ) ->
             UI.Article.Listing.view
                 { config = context.config
                 , cache = context.cache
                 , selection = selection
-                , window = window
+                , limit = limit
                 }
                 subModel
                 |> Html.map ListingMsg

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -26,7 +26,7 @@ module UI.Article.Listing exposing
 import Basics.Extra
 import Cache exposing (Cache)
 import Entities.Document as Document exposing (Document)
-import Entities.DocumentResults exposing (DocumentResult, DocumentsPage)
+import Entities.DocumentResults exposing (DocumentResult)
 import Entities.Markup
 import Entities.PageSequence as PageSequence exposing (PageSequence)
 import Html exposing (Html)
@@ -182,7 +182,7 @@ view context model =
 viewPageSequence : Context -> PageSequence -> Html Msg
 viewPageSequence context pageSequence =
     Html.div []
-        (PageSequence.windowAsList context.limit pageSequence
+        (PageSequence.presentationSegments context.limit pageSequence
             |> List.map
                 (viewPageApiData context)
             |> List.intersperse (Html.hr [] [])
@@ -190,7 +190,7 @@ viewPageSequence context pageSequence =
 
 
 {-| -}
-viewPageApiData : Context -> ApiData DocumentsPage -> Html Msg
+viewPageApiData : Context -> ApiData (List DocumentResult) -> Html Msg
 viewPageApiData context apiData =
     Html.div [] <|
         [ case apiData of
@@ -209,14 +209,14 @@ viewPageApiData context apiData =
         ]
 
 
-viewDocumentsPage : Context -> DocumentsPage -> Html Msg
-viewDocumentsPage context documentsPage =
+viewDocumentsPage : Context -> List DocumentResult -> Html Msg
+viewDocumentsPage context documentResults =
     Html.div []
         [ Html.div
             [ Html.Attributes.class "listing" ]
             (List.map
                 (viewDocumentResult context)
-                documentsPage.content
+                documentResults
             )
         ]
 

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -73,7 +73,7 @@ type alias Model =
 {-| -}
 type Msg
     = SelectDocument DocumentId
-    | ShiftLimit (Int -> Int)
+    | ShowMore
 
 
 
@@ -100,12 +100,12 @@ initialModel =
 update : Context -> Msg -> Model -> ( Model, Cmd Msg, Return )
 update context msg model =
     case msg of
-        ShiftLimit mapping ->
+        ShowMore ->
             ( model
             , Cmd.none
             , Navigate
                 (Navigation.SetLimit
-                    (mapping context.limit |> Basics.Extra.atLeast 0)
+                    (context.limit + 10)
                 )
             )
 
@@ -166,8 +166,7 @@ view context model =
     Html.div [] <|
         -- case model.iterator of
         -- Nothing ->
-        [ viewFooter context
-        , viewPageSequence context
+        [ viewPageSequence context
             (Cache.getDocumentsPages
                 context.cache
                 ( Config.getMaskName MasksConfig.MaskForListing context.config
@@ -360,13 +359,5 @@ viewFooter context =
         [ Html.Attributes.style "margin" "4px 0px 8px 0px"
         , Html.Attributes.class "input-group"
         ]
-        [ {- viewButton { en = "More", de = "mehr" }
-             (PickPosition Next)
-             True
-          -}
-          viewButtonTest "Limit = 0" (ShiftLimit (always 0))
-        , viewButtonTest "Limit + 1" (ShiftLimit ((+) 1))
-        , viewButtonTest "Limit + 4" (ShiftLimit ((+) 4))
-        , viewButtonTest "Limit - 1" (ShiftLimit ((+) -1))
-        , viewButtonTest "Limit - 4" (ShiftLimit ((+) -4))
+        [ viewButton { en = "More Results", de = "weitere Ergebnisse" } ShowMore True
         ]

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -24,6 +24,7 @@ module UI.Article.Listing exposing
 -- import Pagination.Offset.Page as Page exposing (Page, PageResult)
 
 import Cache exposing (Cache)
+import Constants
 import Entities.Document as Document exposing (Document)
 import Entities.DocumentResults exposing (DocumentResult)
 import Entities.Markup
@@ -105,7 +106,7 @@ update context msg model =
             , Cmd.none
             , Navigate
                 (Navigation.SetLimit
-                    (context.limit + 10)
+                    (Constants.incrementLimitOnShowMore context.limit)
                 )
             )
 

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -192,16 +192,19 @@ view context model =
                 , context.selection
                 )
             )
+        , viewFooter context
         ]
 
 
 {-| -}
 viewPageSequence : Context -> PageSequence -> Html Msg
 viewPageSequence context pageSequence =
-    Html.div [] <|
-        List.map
-            (viewPageApiData context)
-            (PageSequence.toList pageSequence)
+    Html.div []
+        (PageSequence.toList pageSequence
+            |> List.map
+                (viewPageApiData context)
+            |> List.intersperse (Html.hr [] [])
+        )
 
 
 {-| -}
@@ -227,14 +230,12 @@ viewPageApiData context apiData =
 viewDocumentsPage : Context -> DocumentsPage -> Html Msg
 viewDocumentsPage context documentsPage =
     Html.div []
-        [ -- viewNumberOfResults page,
-          Html.div
+        [ Html.div
             [ Html.Attributes.class "listing" ]
             (List.map
                 (viewDocumentResult context)
                 documentsPage.content
             )
-        , viewPaginationButtons context.config documentsPage
         ]
 
 
@@ -357,8 +358,8 @@ viewAttribute attribute =
             Html.text ""
 
 
-viewPaginationButtons : Config -> DocumentsPage -> Html Msg
-viewPaginationButtons config documentsPage =
+viewFooter : Context -> Html Msg
+viewFooter context =
     let
         viewButton : Localization.Translations -> Msg -> Bool -> Html Msg
         viewButton label msg enabled =
@@ -367,19 +368,13 @@ viewPaginationButtons config documentsPage =
                 , Html.Attributes.disabled (not enabled)
                 , Html.Events.onClick msg
                 ]
-                [ Localization.text config label ]
+                [ Localization.text context.config label ]
     in
     Html.div
         [ Html.Attributes.style "margin" "4px 0px 8px 0px"
         , Html.Attributes.class "input-group"
         ]
-        [ viewButton { en = "First", de = "zum Anfang" }
-            (PickPosition First)
-            (documentsPage.offset /= 0)
-        , viewButton { en = "Prev", de = "zurück" }
-            (PickPosition Previous)
-            (documentsPage.offset /= 0)
-        , viewButton { en = "Next", de = "weiter" }
+        [ viewButton { en = "More", de = "mehr" }
             (PickPosition Next)
-            documentsPage.hasNextPage
+            True
         ]

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -23,7 +23,6 @@ module UI.Article.Listing exposing
 -- import Article.Iterator as Iterator
 -- import Pagination.Offset.Page as Page exposing (Page, PageResult)
 
-import Basics.Extra
 import Cache exposing (Cache)
 import Entities.Document as Document exposing (Document)
 import Entities.DocumentResults exposing (DocumentResult)

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -200,8 +200,8 @@ viewPageSequence : Context -> PageSequence -> Html Msg
 viewPageSequence context pageSequence =
     Html.div [] <|
         List.map
-            (viewPageApiData context << Tuple.second)
-            pageSequence
+            (viewPageApiData context)
+            (PageSequence.toList pageSequence)
 
 
 {-| -}

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -45,6 +45,7 @@ import Types.Route as Route
 import Types.Route.Url
 import Types.Selection exposing (Selection)
 import UI.Icons
+import Utils
 import Utils.Html
 
 
@@ -162,17 +163,19 @@ update context msg model =
 {-| -}
 view : Context -> Model -> Html Msg
 view context model =
-    Html.div [] <|
-        -- case model.iterator of
-        -- Nothing ->
-        [ viewPageSequence context
-            (Cache.getDocumentsPages
+    let
+        pageSequence =
+            Cache.getDocumentsPages
                 context.cache
                 ( Config.getMaskName MasksConfig.MaskForListing context.config
                 , context.selection
                 )
-            )
-        , viewFooter context
+    in
+    Html.div [] <|
+        -- case model.iterator of
+        -- Nothing ->
+        [ viewPageSequence context pageSequence
+        , viewFooter context pageSequence
         ]
 
 
@@ -338,8 +341,8 @@ viewAttribute attribute =
             Html.text ""
 
 
-viewFooter : Context -> Html Msg
-viewFooter context =
+viewFooter : Context -> PageSequence -> Html Msg
+viewFooter context pageSequence =
     let
         viewButton : Localization.Translations -> Msg -> Bool -> Html Msg
         viewButton label msg enabled =
@@ -353,10 +356,23 @@ viewFooter context =
         viewButtonTest : String -> Msg -> Html Msg
         viewButtonTest text msg =
             viewButton { en = text, de = text } msg True
+
+        canShowMore =
+            PageSequence.canShowMore context.limit pageSequence
     in
-    Html.div
-        [ Html.Attributes.style "margin" "4px 0px 8px 0px"
-        , Html.Attributes.class "input-group"
-        ]
-        [ viewButton { en = "More Results", de = "weitere Ergebnisse" } ShowMore True
-        ]
+    if canShowMore then
+        Html.div
+            [ Html.Attributes.style "margin" "4px 0px 8px 0px"
+            , Html.Attributes.class "input-group"
+            ]
+            [ viewButton { en = "More Results", de = "weitere Ergebnisse" } ShowMore True ]
+
+    else
+        Html.div
+            [ Html.Attributes.style "margin" "4px 0px 8px 0px"
+            , Html.Attributes.class "no-more-results"
+            ]
+            [ Html.hr [] []
+            , Localization.text context.config
+                { en = "No More Results", de = "keine weiteren Ergebnisse" }
+            ]

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -28,6 +28,7 @@ import Cache exposing (Cache)
 import Entities.Document as Document exposing (Document)
 import Entities.DocumentResults exposing (DocumentResult, DocumentsPage)
 import Entities.Markup
+import Entities.PageSequence as PageSequence exposing (PageSequence)
 import Html exposing (Html)
 import Html.Attributes
 import Html.Events
@@ -35,6 +36,7 @@ import Maybe.Extra
 import Regex
 import RemoteData
 import Types exposing (Window)
+import Types.ApiData exposing (ApiData)
 import Types.Config as Config exposing (Config)
 import Types.Config.MasksConfig as MasksConfig
 import Types.Id exposing (DocumentId)
@@ -183,14 +185,30 @@ view context model =
     Html.div [] <|
         -- case model.iterator of
         -- Nothing ->
-        [ case
-            Cache.get
-                context.cache.documentsPages
+        [ viewPageSequence context
+            (Cache.getDocumentsPages
+                context.cache
                 ( Config.getMaskName MasksConfig.MaskForListing context.config
                 , context.selection
-                , context.window
                 )
-          of
+            )
+        ]
+
+
+{-| -}
+viewPageSequence : Context -> PageSequence -> Html Msg
+viewPageSequence context pageSequence =
+    Html.div [] <|
+        List.map
+            (viewPageApiData context << Tuple.second)
+            pageSequence
+
+
+{-| -}
+viewPageApiData : Context -> ApiData DocumentsPage -> Html Msg
+viewPageApiData context apiData =
+    Html.div [] <|
+        [ case apiData of
             RemoteData.NotAsked ->
                 -- Should never happen
                 UI.Icons.spinner

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -35,7 +35,7 @@ import Html.Events
 import Maybe.Extra
 import Regex
 import RemoteData
-import Types exposing (Window)
+import Types
 import Types.ApiData exposing (ApiData)
 import Types.Config as Config exposing (Config)
 import Types.Config.MasksConfig as MasksConfig
@@ -54,7 +54,7 @@ type alias Context =
     { config : Config
     , cache : Cache
     , selection : Selection
-    , window : Window
+    , limit : Int
     }
 
 
@@ -73,7 +73,6 @@ type alias Model =
 {-| -}
 type Msg
     = SelectDocument DocumentId
-    | ShiftOffset (Int -> Int)
     | ShiftLimit (Int -> Int)
 
 
@@ -101,21 +100,12 @@ initialModel =
 update : Context -> Msg -> Model -> ( Model, Cmd Msg, Return )
 update context msg model =
     case msg of
-        ShiftOffset mapping ->
-            ( model
-            , Cmd.none
-            , Navigate
-                (Navigation.SetOffset
-                    (mapping context.window.offset |> Basics.Extra.atLeast 0)
-                )
-            )
-
         ShiftLimit mapping ->
             ( model
             , Cmd.none
             , Navigate
                 (Navigation.SetLimit
-                    (mapping context.window.limit |> Basics.Extra.atLeast 0)
+                    (mapping context.limit |> Basics.Extra.atLeast 0)
                 )
             )
 
@@ -192,7 +182,7 @@ view context model =
 viewPageSequence : Context -> PageSequence -> Html Msg
 viewPageSequence context pageSequence =
     Html.div []
-        (PageSequence.windowAsList context.window pageSequence
+        (PageSequence.windowAsList context.limit pageSequence
             |> List.map
                 (viewPageApiData context)
             |> List.intersperse (Html.hr [] [])
@@ -374,13 +364,7 @@ viewFooter context =
              (PickPosition Next)
              True
           -}
-          viewButtonTest "Offset = 0" (ShiftOffset (always 0))
-        , viewButtonTest "Offset + 1" (ShiftOffset ((+) 1))
-        , viewButtonTest "Offset + 4" (ShiftOffset ((+) 4))
-        , viewButtonTest "Offset - 1" (ShiftOffset ((+) -1))
-        , viewButtonTest "Offset - 4" (ShiftOffset ((+) -4))
-        , Html.br [] []
-        , viewButtonTest "Limit = 0" (ShiftLimit (always 0))
+          viewButtonTest "Limit = 0" (ShiftLimit (always 0))
         , viewButtonTest "Limit + 1" (ShiftLimit ((+) 1))
         , viewButtonTest "Limit + 4" (ShiftLimit ((+) 4))
         , viewButtonTest "Limit - 1" (ShiftLimit ((+) -1))

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -362,11 +362,30 @@ viewFooter context pageSequence =
             PageSequence.canShowMore context.limit pageSequence
     in
     if canShowMore then
-        Html.div
-            [ Html.Attributes.style "margin" "4px 0px 8px 0px"
-            , Html.Attributes.class "input-group"
-            ]
-            [ viewButton { en = "More Results", de = "weitere Ergebnisse" } ShowMore True ]
+        if context.limit < context.config.maxLimit then
+            Html.div
+                [ Html.Attributes.style "margin" "4px 0px 8px 0px"
+                , Html.Attributes.class "input-group"
+                ]
+                [ viewButton
+                    { en = "More Results"
+                    , de = "weitere Ergebnisse"
+                    }
+                    ShowMore
+                    True
+                ]
+
+        else
+            Html.div
+                [ Html.Attributes.style "margin" "4px 0px 8px 0px"
+                , Html.Attributes.class "no-more-results"
+                ]
+                [ Html.hr [] []
+                , Localization.text context.config
+                    { en = "Maximum Number of Results Reached"
+                    , de = "maximale Anzahl von Ergebnissen erreicht"
+                    }
+                ]
 
     else
         Html.div
@@ -375,5 +394,7 @@ viewFooter context pageSequence =
             ]
             [ Html.hr [] []
             , Localization.text context.config
-                { en = "No More Results", de = "keine weiteren Ergebnisse" }
+                { en = "No More Results"
+                , de = "keine weiteren Ergebnisse"
+                }
             ]

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -25,7 +25,7 @@ module UI.Tree exposing
 
 -}
 
-import Cache exposing (ApiData, Cache)
+import Cache exposing (Cache)
 import Cache.Derive
 import Entities.Folder as Folder exposing (Folder)
 import Entities.FolderCounts exposing (FolderCounts)
@@ -35,6 +35,7 @@ import Html.Events
 import RemoteData
 import Sort.Dict
 import Types exposing (FolderDisplay(..))
+import Types.ApiData exposing (ApiData)
 import Types.Config exposing (Config)
 import Types.Id exposing (FolderId)
 import Types.Needs

--- a/frontend/src/elm/UI/Widgets/Breadcrumbs.elm
+++ b/frontend/src/elm/UI/Widgets/Breadcrumbs.elm
@@ -59,6 +59,7 @@ view context maybeLineage =
                                             Html.a
                                                 [ context.route
                                                     |> Navigation.alterRoute
+                                                        context.config
                                                         context.cache
                                                         (Navigation.ShowListingWithFolder folderId)
                                                     |> Types.Route.Url.toString context.config

--- a/frontend/src/elm/Utils/Html.elm
+++ b/frontend/src/elm/Utils/Html.elm
@@ -19,12 +19,13 @@ import Cache
 import Cache.Derive
 import Html exposing (Attribute, Html)
 import Html.Attributes
+import Types.ApiData as ApiData exposing (ApiData, ApiError)
 
 
 {-| -}
-viewApiError : Cache.ApiError -> Html msg
+viewApiError : ApiError -> Html msg
 viewApiError error =
-    viewError (Cache.apiErrorToString error)
+    viewError (ApiData.apiErrorToString error)
 
 
 {-| -}

--- a/frontend/tests/Tests/Types.elm
+++ b/frontend/tests/Tests/Types.elm
@@ -7,7 +7,7 @@ module Tests.Types exposing
     , fuzzerGlobalFts
     , fuzzerLimit
     , fuzzerMaskDocumentIdFromSearch
-    , fuzzerMaskSelectionWindow
+    , fuzzerMaskSelection
     , fuzzerNodeId
     , fuzzerOffset
     , fuzzerSelection
@@ -92,12 +92,11 @@ fuzzerSelectionWindow =
         fuzzerWindow
 
 
-fuzzerMaskSelectionWindow : Fuzzer ( String, Selection, Window )
-fuzzerMaskSelectionWindow =
-    Fuzz.map3 (\maskName selection window -> ( maskName, selection, window ))
+fuzzerMaskSelection : Fuzzer ( String, Selection )
+fuzzerMaskSelection =
+    Fuzz.map2 Tuple.pair
         fuzzerMaskName
         fuzzerSelection
-        fuzzerWindow
 
 
 fuzzerSelectionFacets : Fuzzer ( Selection, List Aspect )

--- a/frontend/tests/Tests/Types/Ordering.elm
+++ b/frontend/tests/Tests/Types/Ordering.elm
@@ -20,7 +20,7 @@ suite =
         , testFineOrderingProperties "DocumentIdFromSearch" fuzzerDocumentIdFromSearch Types.orderingDocumentIdFromSearch
         , testFineOrderingProperties "MaskDocumentIdFromSearch" fuzzerMaskDocumentIdFromSearch Cache.orderingMaskDocumentIdFromSearch
         , testFineOrderingProperties "SelectionWindow" fuzzerSelectionWindow Cache.orderingSelectionWindow
-        , testFineOrderingProperties "MaskSelectionWindow" fuzzerMaskSelectionWindow Cache.orderingMaskSelectionWindow
+        , testFineOrderingProperties "MaskSelection" fuzzerMaskSelection Cache.orderingMaskSelection
         , testCoarseOrderingProperties "SelectionFacets" fuzzerSelectionFacets Cache.orderingSelectionFacets
         , testFineOrderingProperties "SearchMethod" fuzzerGlobalFts Selection.orderingGlobalFts
         , testFineOrderingProperties "Sorting" fuzzerSorting Selection.orderingSorting

--- a/frontend/tests/Tests/Types/Route.elm
+++ b/frontend/tests/Tests/Types/Route.elm
@@ -25,7 +25,5 @@ fuzzerRoute =
             |> Fuzz.andMap
                 Tests.Types.fuzzerFacetFilters
             |> Fuzz.andMap
-                fuzzerOffset
-            |> Fuzz.andMap
                 fuzzerLimit
         )

--- a/frontend/tests/Tests/Types/Route/Url.elm
+++ b/frontend/tests/Tests/Types/Route/Url.elm
@@ -123,13 +123,13 @@ suite =
                         , Types.Route.Url.toString testConfig >> Expect.equal "/123/456?search=foo"
                         ]
             , describe "It should remove search terms that are empty"
-                [ testString "https://example.com/?search=&offset=7" <|
+                [ testString "https://example.com/?search=&limit=7" <|
                     Url.fromString
                         >> Maybe.andThen (Types.Route.Url.parseUrl testConfig)
                         >> justAndThenAll
                             [ .parameters >> .globalFts >> nothing
-                            , .parameters >> .offset >> Expect.equal 7
-                            , Types.Route.Url.toString testConfig >> Expect.equal "/?offset=7"
+                            , .parameters >> .limit >> Expect.equal 7
+                            , Types.Route.Url.toString testConfig >> Expect.equal "/?limit=7"
                             ]
                 ]
             , describe "It should remove whitespace on both sides of a search term"
@@ -143,12 +143,12 @@ suite =
                             ]
                 ]
             , describe "It should remove search terms that are only whitespace"
-                [ testString "https://example.com/?search=%20%20&offset=7" <|
+                [ testString "https://example.com/?search=%20%20&limit=7" <|
                     Url.fromString
                         >> Maybe.andThen (Types.Route.Url.parseUrl testConfig)
                         >> justAndThenAll
                             [ .parameters >> .globalFts >> nothing
-                            , .parameters >> .offset >> Expect.equal 7
+                            , .parameters >> .limit >> Expect.equal 7
                             ]
                 ]
             , describe "It should remove fts filter terms that are empty or only whitespace"


### PR DESCRIPTION
Formerly we presented listings of documents page by page.

Now we present listings starting from the beginning and ending at a certain limit.
This user can increase this limit by clicking a "Show More" button.
The client will then load more results from the server and append them to the existing results.

We define a new type `Entities.PageSequence` for caching these incrementally loaded listings.
