### PR TITLE
Limit attribute length in listing view

### DIFF
--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -1,12 +1,14 @@
 module Constants exposing
     ( apiUrl, graphqlOperationNamePrefix
     , incrementLimitOnShowMore
+    , maxAttributeLengthInListingView
     )
 
 {-| Configurable values
 
 @docs apiUrl, graphqlOperationNamePrefix
 @docs incrementLimitOnShowMore
+@docs maxAttributeLengthInListingView
 
 -}
 
@@ -42,3 +44,9 @@ incrementLimitOnShowMore limit =
 
     else
         ((limit + 149) // 100) * 100
+
+
+{-| -}
+maxAttributeLengthInListingView : Int
+maxAttributeLengthInListingView =
+    200

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -314,7 +314,9 @@ viewAttribute attribute =
                 ]
                 (let
                     markup =
-                        Entities.Markup.view value
+                        value
+                            |> Entities.Markup.trim Constants.maxAttributeLengthInListingView
+                            |> Entities.Markup.view
                  in
                  if isField "year" then
                     [ value |> Entities.Markup.normalizeYear |> Entities.Markup.view

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -35,7 +35,6 @@ import Html.Events
 import Maybe.Extra
 import Regex
 import RemoteData
-import Types
 import Types.ApiData exposing (ApiData)
 import Types.Config as Config exposing (Config)
 import Types.Config.MasksConfig as MasksConfig
@@ -46,7 +45,6 @@ import Types.Route as Route
 import Types.Route.Url
 import Types.Selection exposing (Selection)
 import UI.Icons
-import Utils
 import Utils.Html
 
 
@@ -292,23 +290,41 @@ maxAttributeStringLength =
     80
 
 
+keys :
+    { author : Regex.Regex
+    , congressOrJournal : Regex.Regex
+    , title : Regex.Regex
+    , titleOrType : Regex.Regex
+    , year : Regex.Regex
+    }
+keys =
+    let
+        regex regexString =
+            Maybe.withDefault Regex.never (Regex.fromString regexString)
+    in
+    { author = regex "author"
+    , title = regex "title"
+    , congressOrJournal = regex "congress|journal"
+    , year = regex "year"
+    , titleOrType = regex "title|type"
+    }
+
+
 viewAttribute : Document.Attribute -> Html msg
 viewAttribute attribute =
     let
-        isField regexString =
-            Regex.contains
-                (Maybe.withDefault Regex.never (Regex.fromString regexString))
-                attribute.field
+        isField regex =
+            Regex.contains regex attribute.field
     in
     case attribute.value of
         Just value ->
             Html.span
                 [ Html.Attributes.classList
                     [ ( "attribute", True )
-                    , ( "author", isField "author" )
+                    , ( "author", isField keys.author )
                     , ( "title"
-                      , isField "title"
-                            && not (isField "congress|journal")
+                      , isField keys.title
+                            && not (isField keys.congressOrJournal)
                       )
                     ]
                 ]
@@ -318,17 +334,17 @@ viewAttribute attribute =
                             |> Entities.Markup.trim Constants.maxAttributeLengthInListingView
                             |> Entities.Markup.view
                  in
-                 if isField "year" then
+                 if isField keys.year then
                     [ value |> Entities.Markup.normalizeYear |> Entities.Markup.view
                     , Html.text ". "
                     ]
 
-                 else if isField "author" then
+                 else if isField keys.author then
                     [ markup
                     , Html.text ": "
                     ]
 
-                 else if isField "title|type" then
+                 else if isField keys.titleOrType then
                     [ markup
                     , Html.text ". "
                     ]


### PR DESCRIPTION
There are documents in the database with very long author fields.

In order not to break the layout of document listings we limit the length of all attributes to a certain number of characters in this view. This truncation respects word boundaries and highlighted terms.

This number is defined in `Constants.maxAttributeLengthInListingView`, e.g. `200`.