### PR TITLE
Layout improvements in listing view and details view

### DIFF
--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -324,3 +324,43 @@ ul.folder-list ul.folder-list {
 .facet-value-count {
   margin-left: 0.2em;
 }
+
+
+
+/* Small waiting animation with three dots */
+.spinner-small, .spinner-small::before, .spinner-small::after {
+  width: 4px;
+  height: 4px;
+  border-radius: 2px;
+  background-color:#333;
+  color: #333;
+  animation: spinner-small 1s infinite alternate;
+}
+
+.spinner-small {
+  position: relative;
+  animation-delay: .5s;
+  margin: 0.5em;
+}
+
+.spinner-small::before, .spinner-small::after {
+  content: '';
+  display: inline-block;
+  position: absolute;
+  top: 0;
+}
+
+.spinner-small::before {
+  left: -7px;
+  animation-delay: 0s;
+}
+
+.spinner-small::after {
+  left: 7px;
+  animation-delay: 1s;
+}
+
+@keyframes spinner-small {
+  0% { background-color: #333; }
+  60%, 100% { background-color: #ccc; }
+}

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -256,13 +256,9 @@ ul.folder-list ul.folder-list {
 .spinner {
   width: 3em;
 }
-.article .spinner {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+.text-align-center {
+  text-align: center;
 }
-
 .error {
   color: #3070b3;
 }

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -268,6 +268,10 @@ ul.folder-list ul.folder-list {
 .residence .title {
   font-weight: bold;
 }
+.details .search-matching{
+  margin-top: 4ex;
+  font-weight: bold;
+}
 .breadcrumbs {
   font-size: 80%;
   color: #737373

--- a/frontend/src/elm/Entities/Markup.elm
+++ b/frontend/src/elm/Entities/Markup.elm
@@ -2,6 +2,7 @@ module Entities.Markup exposing
     ( Markup
     , parse
     , empty, plainText, normalizeYear
+    , isEmpty
     , trim, view
     )
 
@@ -10,6 +11,7 @@ module Entities.Markup exposing
 @docs Markup
 @docs parse
 @docs empty, plainText, normalizeYear
+@docs isEmpty
 @docs trim, view
 
 -}
@@ -31,6 +33,11 @@ type Markup
 empty : Markup
 empty =
     Markup []
+
+
+isEmpty : Markup -> Bool
+isEmpty (Markup segments) =
+    segments == []
 
 
 {-| Decompose a string with markup.

--- a/frontend/src/elm/Entities/Markup.elm
+++ b/frontend/src/elm/Entities/Markup.elm
@@ -35,6 +35,8 @@ empty =
     Markup []
 
 
+{-| Determine if the Markup contains no text
+-}
 isEmpty : Markup -> Bool
 isEmpty (Markup segments) =
     segments == []

--- a/frontend/src/elm/Entities/PageSequence.elm
+++ b/frontend/src/elm/Entities/PageSequence.elm
@@ -1,6 +1,6 @@
 module Entities.PageSequence exposing
     ( PageSequence, init
-    , PresentationSegments, presentationSegments, canShowMore
+    , PresentationSegments, presentationSegments, canShowMore, remoteDataIsSuccess
     , statusOfNeededWindow, requestWindow, updatePageResult
     )
 
@@ -12,7 +12,7 @@ The type `PageSequence` represents such a sequence of pages as it is stored in t
 The segmentation of the listing into pages reflects the history of requests to prolong the listing.
 
 @docs PageSequence, init
-@docs PresentationSegments, presentationSegments, canShowMore
+@docs PresentationSegments, presentationSegments, canShowMore, remoteDataIsSuccess
 
 @docs statusOfNeededWindow, requestWindow, updatePageResult
 
@@ -77,6 +77,15 @@ presentationSegments limit (PageSequence array complete) =
 canShowMore : Int -> PageSequence -> Bool
 canShowMore limit (PageSequence array complete) =
     not complete || limit < numberOfResults array
+
+
+{-| -}
+remoteDataIsSuccess : PageSequence -> Bool
+remoteDataIsSuccess (PageSequence array complete) =
+    array
+        |> Array.toList
+        |> List.all
+            (Tuple.second >> RemoteData.isSuccess)
 
 
 {-| Determine if a given page sequence fulfills the needs to show a given window of a listing

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -258,13 +258,17 @@ viewAttribute : Document.Attribute -> Html msg
 viewAttribute attribute =
     case attribute.value of
         Just value ->
-            Html.tr
-                [ Html.Attributes.class "attribute" ]
-                [ Html.td [] [ Html.text attribute.name ]
-                , Html.td []
-                    [ Entities.Markup.view value
+            if Entities.Markup.isEmpty value then
+                Html.text ""
+
+            else
+                Html.tr
+                    [ Html.Attributes.class "attribute" ]
+                    [ Html.td [] [ Html.text attribute.name ]
+                    , Html.td []
+                        [ Entities.Markup.view value
+                        ]
                     ]
-                ]
 
         Nothing ->
             Html.text ""

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -227,8 +227,8 @@ viewDocument context model document residence =
         ]
 
 
-viewSearchMatching : Config -> Maybe Document.SearchMatching -> Html msg
-viewSearchMatching config =
+viewSearchMatching_1 : Config -> Maybe Document.SearchMatching -> Html msg
+viewSearchMatching_1 config =
     Maybe.Extra.unwrap
         { en = "", de = "" }
         (\{ attributes, fulltext } ->
@@ -252,6 +252,42 @@ viewSearchMatching config =
                     }
         )
         >> Localization.text config
+
+
+viewSearchMatching : Config -> Maybe Document.SearchMatching -> Html msg
+viewSearchMatching config maybeSearchMatching =
+    case maybeSearchMatching of
+        Nothing ->
+            Html.text ""
+
+        Just { attributes, fulltext } ->
+            let
+                block translations =
+                    Html.div
+                        [ Html.Attributes.class "search-matching" ]
+                        [ Localization.text config translations ]
+            in
+            case ( attributes, fulltext ) of
+                ( False, False ) ->
+                    Html.text ""
+
+                ( True, False ) ->
+                    block
+                        { en = "Search term found in metadata"
+                        , de = "Suchbegriff in Metadaten gefunden"
+                        }
+
+                ( False, True ) ->
+                    block
+                        { en = "Search term found in fulltext"
+                        , de = "Suchbegriff in Volltext gefunden"
+                        }
+
+                ( True, True ) ->
+                    block
+                        { en = "Search term found in metadata and fulltext"
+                        , de = "Suchbegriff in Metadaten und Volltext gefunden"
+                        }
 
 
 viewAttribute : Document.Attribute -> Html msg

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -196,10 +196,10 @@ viewPageApiData context apiData =
         [ case apiData of
             RemoteData.NotAsked ->
                 -- Should never happen
-                UI.Icons.spinner
+                viewSpinner
 
             RemoteData.Loading ->
-                UI.Icons.spinner
+                viewSpinner
 
             RemoteData.Failure error ->
                 Utils.Html.viewApiError error
@@ -207,6 +207,13 @@ viewPageApiData context apiData =
             RemoteData.Success documentsPage ->
                 viewDocumentsPage context documentsPage
         ]
+
+
+viewSpinner : Html msg
+viewSpinner =
+    Html.div
+        [ Html.Attributes.class "text-align-center" ]
+        [ UI.Icons.spinner ]
 
 
 viewDocumentsPage : Context -> List DocumentResult -> Html Msg

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -397,7 +397,7 @@ viewFooter context pageSequence =
                     , de = "weitere Ergebnisse"
                     }
                     ShowMore
-                    True
+                    (PageSequence.remoteDataIsSuccess pageSequence)
                 ]
 
         else

--- a/frontend/src/elm/UI/Facets.elm
+++ b/frontend/src/elm/UI/Facets.elm
@@ -137,10 +137,10 @@ viewFacet context selection facetAspectConfig =
                     of
                         RemoteData.NotAsked ->
                             -- Should never happen
-                            UI.Icons.spinner
+                            UI.Icons.spinnerSmall
 
                         RemoteData.Loading ->
-                            UI.Icons.spinner
+                            UI.Icons.spinnerSmall
 
                         RemoteData.Failure error ->
                             Utils.Html.viewApiError error

--- a/frontend/src/elm/UI/Icons.elm
+++ b/frontend/src/elm/UI/Icons.elm
@@ -5,6 +5,7 @@ module UI.Icons exposing
     , search
     , clear
     , spinner
+    , spinnerSmall
     )
 
 {-|
@@ -19,6 +20,7 @@ module UI.Icons exposing
 -}
 
 import Html exposing (Html)
+import Html.Attributes
 import Svg exposing (Svg)
 import Svg.Attributes
 
@@ -129,3 +131,12 @@ spinner =
                 ]
             ]
         ]
+
+
+{-| Smaller icon for waiting state. Uses CSS animation
+-}
+spinnerSmall : Html msg
+spinnerSmall =
+    Html.div
+        [ Html.Attributes.class "spinner-small" ]
+        []

--- a/frontend/src/elm/UI/Icons.elm
+++ b/frontend/src/elm/UI/Icons.elm
@@ -4,8 +4,7 @@ module UI.Icons exposing
     , leaf
     , search
     , clear
-    , spinner
-    , spinnerSmall
+    , spinner, spinnerSmall
     )
 
 {-|
@@ -15,7 +14,7 @@ module UI.Icons exposing
 @docs leaf
 @docs search
 @docs clear
-@docs spinner
+@docs spinner, spinnerSmall
 
 -}
 

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -138,10 +138,10 @@ viewListOfFolders context model maybeFolderCounts apiDataFolderIds =
     Html.ul [ Html.Attributes.class "folder-list" ] <|
         case apiDataFolderIds of
             RemoteData.NotAsked ->
-                [ Html.li [] [ Html.text "..." ] ]
+                [ Html.li [] [ UI.Icons.spinnerSmall ] ]
 
             RemoteData.Loading ->
-                [ Html.li [] [ Html.text "..." ] ]
+                [ Html.li [] [ UI.Icons.spinnerSmall ] ]
 
             RemoteData.Success folderIds ->
                 List.map
@@ -160,10 +160,10 @@ viewFolderTree context model maybeFolderCounts id =
     Html.div [] <|
         case Cache.get context.cache.folders id of
             RemoteData.NotAsked ->
-                [ Html.text "..." ]
+                [ UI.Icons.spinnerSmall ]
 
             RemoteData.Loading ->
-                [ Html.text "..." ]
+                [ UI.Icons.spinnerSmall ]
 
             RemoteData.Success folder ->
                 let


### PR DESCRIPTION
- Fix positioning of spinner in listing view
- Disable "More" button in listing view while loading
- Use smaller spinner icon in tree and facet views
- Hide empty attributes in details view
- Layout of search matching indication in details view
