### PR TITLE
Remove code for mutating document attributes in details view

### DIFF
--- a/frontend/src/elm/Api/Mutations.elm
+++ b/frontend/src/elm/Api/Mutations.elm
@@ -21,7 +21,7 @@ import Mediatum.Object.UpdateDocumentAttributePayload
 import Types.Id as Id exposing (DocumentId)
 
 
-{-| Set an attribute of a document selected by a mediaTUM id.
+{-| Set an attribute of a document selected by a mediaTUM id. (Currently not used.)
 
 Returns the new document details based on the mediaTUM mask "nodebig".
 

--- a/frontend/src/elm/App.elm
+++ b/frontend/src/elm/App.elm
@@ -245,17 +245,6 @@ updateSubModel context msg model =
                         UI.Navigate navigation ->
                             ( model1, SubReturnNavigate navigation )
 
-                        UI.UpdateCacheWithModifiedDocument document ->
-                            ( { model1
-                                | cache =
-                                    Cache.updateWithModifiedDocument
-                                        (Config.getMaskName MasksConfig.MaskForDetails context.config)
-                                        document
-                                        model1.cache
-                              }
-                            , SubNoReturn
-                            )
-
                         UI.SwitchUILanguage language ->
                             ( model1, SubReturnSwitchUILanguage language )
             in

--- a/frontend/src/elm/Cache.elm
+++ b/frontend/src/elm/Cache.elm
@@ -1,7 +1,6 @@
 module Cache exposing
     ( Cache, get, getDocumentsPages
     , Need(..), Needs, targetNeeds
-    , updateWithModifiedDocument
     , Msg(..), init, update
     , orderingSelectionWindow, orderingMaskSelection, orderingSelectionFacets, orderingMaskDocumentIdFromSearch
     )
@@ -26,11 +25,6 @@ So the consuming modules will have to deal with the possible states a `RemoteDat
 # Declaring required data
 
 @docs Need, Needs, targetNeeds
-
-
-# Modifying data locally (preliminary)
-
-@docs updateWithModifiedDocument
 
 
 # Elm architecture standard functions
@@ -344,19 +338,6 @@ requestNeed config need cache =
                 (ApiResponseFacets ( selection, aspects ))
                 (Api.Queries.selectionFacets selection aspects config.numberOfFacetValues)
             )
-
-
-{-| Insert or update a document into the table `Cache.documents`.
--}
-updateWithModifiedDocument : String -> Document -> Cache -> Cache
-updateWithModifiedDocument maskName document cache =
-    { cache
-        | documents =
-            Sort.Dict.insert
-                ( maskName, DocumentIdFromSearch document.id Nothing )
-                (Success document)
-                cache.documents
-    }
 
 
 {-| Digest a Msg (i.e. a response from the API layer) and update the data in the cache accordingly.

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -48,7 +48,6 @@ Mainly used to report navigational requests.
 type Return
     = NoReturn
     | Navigate Navigation
-    | UpdateCacheWithModifiedDocument Document
     | SwitchUILanguage Language
 
 
@@ -228,9 +227,6 @@ update context msg model =
 
                 UI.Article.Navigate navigation ->
                     Navigate navigation
-
-                UI.Article.UpdateCacheWithModifiedDocument document ->
-                    UpdateCacheWithModifiedDocument document
             )
 
 

--- a/frontend/src/elm/UI/Article.elm
+++ b/frontend/src/elm/UI/Article.elm
@@ -26,7 +26,7 @@ module UI.Article exposing
 
 import Cache exposing (Cache)
 import Cache.Derive
-import Entities.Document exposing (Document)
+import Entities.Document
 import Entities.FolderCounts exposing (FolderCounts)
 import Html exposing (Html)
 import Html.Attributes
@@ -61,7 +61,6 @@ type alias Context =
 type Return
     = NoReturn
     | Navigate Navigation
-    | UpdateCacheWithModifiedDocument Document
 
 
 {-| -}
@@ -235,9 +234,6 @@ update context msg model =
             , case subReturn of
                 UI.Article.Details.NoReturn ->
                     NoReturn
-
-                UI.Article.Details.UpdateCacheWithModifiedDocument document ->
-                    UpdateCacheWithModifiedDocument document
             )
 
         _ ->


### PR DESCRIPTION
The code was there to demonstrate how mutations can be implemented in our architecture.

It could guide first steps to implement a mediaTUM editor.