### PR TITLE
Behavior and layout of listing view 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "compile": "rimraf elm-stuff && ncp src/assets dist && elm make --output=dist/app.js src/elm/Main.elm",
     "build": "npm run generate && npm run compile",
     "start": "ncp src/assets dist && elm-live -u -e node_modules/.bin/elm -d dist src/elm/Main.elm -x /graphql -y http://localhost:5000/graphql -- --output=dist/app.js --debug",
+    "start-no-reload": "ncp src/assets dist && elm-live --no-reload -u -e node_modules/.bin/elm -d dist src/elm/Main.elm -x /graphql -y http://localhost:5000/graphql -- --output=dist/app.js --debug",
     "format": "elm-format --yes src/elm tests",
     "doc-preview": "elm-doc-preview --port 8001 --no-browser .",
     "clean": "rimraf gen elm-stuff",

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -179,11 +179,24 @@ button.filter-button, .filter-inputs {
   padding: 0.25rem .75rem;
 }
 
-
-
-
 .document {
+  display: block;
   margin: 2ex 0;
+  padding: 1px 3px;
+  border: 1px solid transparent;
+}
+.document:hover {
+  border: 1px solid #a0af00;
+}
+a.document {
+  color: unset;
+  text-decoration: unset;
+}
+a.document:hover {
+  text-decoration: unset;
+}
+.document .metadatatype {
+  color: #4889ce;
 }
 .listing .attributes {
   margin-left: 2em;

--- a/frontend/src/elm/Types/Navigation.elm
+++ b/frontend/src/elm/Types/Navigation.elm
@@ -1,22 +1,27 @@
 module Types.Navigation exposing
     ( Navigation(..)
     , alterRoute
+    , Context, alterRouteHref
     )
 
 {-| A navigation is an instruction to alter a given route in response to some user interaction.
 
 @docs Navigation
 @docs alterRoute
+@docs Context, alterRouteHref
 
 -}
 
 import Cache exposing (Cache)
 import Cache.Derive
+import Html
+import Html.Attributes
 import Types.Aspect exposing (Aspect)
 import Types.Config exposing (Config)
 import Types.FilterList as FilterList
 import Types.Id as Id exposing (DocumentId, FolderId)
 import Types.Route as Route exposing (Route)
+import Types.Route.Url
 import Types.Selection exposing (FtsFilters, GlobalFts, Sorting)
 
 
@@ -117,3 +122,22 @@ alterRoute config cache navigation route =
                 | parameters =
                     { parameters | limit = limit }
             }
+
+
+{-| Any context type that exposes the necessary fields config, cache and route
+-}
+type alias Context c =
+    { c
+        | config : Config
+        , cache : Cache
+        , route : Route
+    }
+
+
+{-| Get a href for a link to an altered route according to a navigation.
+-}
+alterRouteHref : Context c -> Navigation -> Html.Attribute msg
+alterRouteHref context navigation =
+    alterRoute context.config context.cache navigation context.route
+        |> Types.Route.Url.toString context.config
+        |> Html.Attributes.href

--- a/frontend/src/elm/UI/Article.elm
+++ b/frontend/src/elm/UI/Article.elm
@@ -199,6 +199,7 @@ update context msg model =
                     UI.Article.Listing.update
                         { config = context.config
                         , cache = context.cache
+                        , route = context.route
                         , selection = selection
                         , limit = limit
                         }
@@ -289,6 +290,7 @@ viewContent context model =
             UI.Article.Listing.view
                 { config = context.config
                 , cache = context.cache
+                , route = context.route
                 , selection = selection
                 , limit = limit
                 }

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -322,43 +322,47 @@ viewAttribute attribute =
     in
     case attribute.value of
         Just value ->
-            Html.span
-                [ Html.Attributes.classList
-                    [ ( "attribute", True )
-                    , ( "author", isField keys.author )
-                    , ( "title"
-                      , isField keys.title
-                            && not (isField keys.congressOrJournal)
-                      )
-                    ]
-                ]
-                (let
-                    markup =
-                        value
-                            |> Entities.Markup.trim Constants.maxAttributeLengthInListingView
-                            |> Entities.Markup.view
-                 in
-                 if isField keys.year then
-                    [ value |> Entities.Markup.normalizeYear |> Entities.Markup.view
-                    , Html.text ". "
-                    ]
+            if Entities.Markup.isEmpty value then
+                Html.text ""
 
-                 else if isField keys.author then
-                    [ markup
-                    , Html.text ": "
+            else
+                Html.span
+                    [ Html.Attributes.classList
+                        [ ( "attribute", True )
+                        , ( "author", isField keys.author )
+                        , ( "title"
+                          , isField keys.title
+                                && not (isField keys.congressOrJournal)
+                          )
+                        ]
                     ]
+                    (let
+                        markup =
+                            value
+                                |> Entities.Markup.trim Constants.maxAttributeLengthInListingView
+                                |> Entities.Markup.view
+                     in
+                     if isField keys.year then
+                        [ value |> Entities.Markup.normalizeYear |> Entities.Markup.view
+                        , Html.text ". "
+                        ]
 
-                 else if isField keys.titleOrType then
-                    [ markup
-                    , Html.text ". "
-                    ]
+                     else if isField keys.author then
+                        [ markup
+                        , Html.text ": "
+                        ]
 
-                 else
-                    [ Html.text (attribute.name ++ ": ")
-                    , markup
-                    , Html.text ". "
-                    ]
-                )
+                     else if isField keys.titleOrType then
+                        [ markup
+                        , Html.text ". "
+                        ]
+
+                     else
+                        [ Html.text (attribute.name ++ ": ")
+                        , markup
+                        , Html.text ". "
+                        ]
+                    )
 
         Nothing ->
             Html.text ""

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -41,8 +41,7 @@ import Types.Config.MasksConfig as MasksConfig
 import Types.Id exposing (DocumentId)
 import Types.Localization as Localization
 import Types.Navigation as Navigation exposing (Navigation)
-import Types.Route as Route
-import Types.Route.Url
+import Types.Route exposing (Route)
 import Types.Selection exposing (Selection)
 import UI.Icons
 import Utils.Html
@@ -52,6 +51,7 @@ import Utils.Html
 type alias Context =
     { config : Config
     , cache : Cache
+    , route : Route
     , selection : Selection
     , limit : Int
     }
@@ -238,20 +238,17 @@ viewDocumentResult context documentResult =
 
 viewDocument : Context -> Int -> Document -> Html Msg
 viewDocument context number document =
-    Html.div [ Html.Attributes.class "document" ]
+    Html.a
+        [ Html.Attributes.class "document"
+        , Navigation.alterRouteHref
+            context
+            (Navigation.ShowDocument context.selection.scope document.id)
+        ]
         [ Html.div [ Html.Attributes.class "metadatatype" ]
             [ Html.span [ Html.Attributes.class "result-number" ]
-                [ Html.text <| String.fromInt number ++ ". " ]
-            , Html.a
-                [ Html.Attributes.class "metadatatype"
-                , Route.initDocumentInFolder
-                    context.config
-                    context.selection.scope
-                    document.id
-                    |> Types.Route.Url.toString context.config
-                    |> Html.Attributes.href
+                [ Html.text <| String.fromInt number ++ ". "
+                , Html.text document.metadatatypeName
                 ]
-                [ Html.text document.metadatatypeName ]
             ]
         , Html.div
             [ Html.Attributes.class "attributes"

--- a/frontend/src/elm/UI/Widgets/Breadcrumbs.elm
+++ b/frontend/src/elm/UI/Widgets/Breadcrumbs.elm
@@ -19,11 +19,11 @@ import Types.Config exposing (Config)
 import Types.Id exposing (FolderId)
 import Types.Navigation as Navigation
 import Types.Route exposing (Route)
-import Types.Route.Url
 import Utils.List
 
 
-{-| -}
+{-| Any context type that exposes the necessary fields config, cache and route
+-}
 type alias Context c =
     { c
         | config : Config
@@ -57,13 +57,9 @@ view context maybeLineage =
                                     |> Maybe.map
                                         (\folder ->
                                             Html.a
-                                                [ context.route
-                                                    |> Navigation.alterRoute
-                                                        context.config
-                                                        context.cache
-                                                        (Navigation.ShowListingWithFolder folderId)
-                                                    |> Types.Route.Url.toString context.config
-                                                    |> Html.Attributes.href
+                                                [ Navigation.alterRouteHref
+                                                    context
+                                                    (Navigation.ShowListingWithFolder folderId)
                                                 ]
                                                 [ Html.text folder.name ]
                                         )


### PR DESCRIPTION
- Each entry in a listing is now an html anchor, linking to the details view.
- These links preserve the search-related URL parameters, e.g. for highlighting search-term occurrences.
- Hide empty attributes in listing view
- Some styling of the listing entries