### PR TITLE
Various fixes of the behavior of the tree control

### DIFF
--- a/frontend/src/elm/App.elm
+++ b/frontend/src/elm/App.elm
@@ -113,19 +113,19 @@ updateModelFromRoute context route model =
             }
 
         model3 =
-            adjustPresentation context.config model2
+            adjustPresentation context model2
     in
     model3
 
 
 {-| Derive the current presentation from the route using contextual knowledge from the cache and update the UI accordingly.
 -}
-adjustPresentation : Config -> Model -> Model
-adjustPresentation config model =
+adjustPresentation : Context -> Model -> Model
+adjustPresentation context model =
     let
         presentation =
             Presentation.fromRoute
-                config
+                context.config
                 model.cache
                 model.route
     in
@@ -135,11 +135,14 @@ adjustPresentation config model =
         model
 
     else
-        { model
-            | presentation = presentation
-            , ui =
+        let
+            model1 =
+                { model | presentation = presentation }
+        in
+        { model1
+            | ui =
                 UI.updateOnChangedPresentation
-                    presentation
+                    (uiContext context model1)
                     model.ui
         }
 
@@ -221,7 +224,7 @@ updateSubModel context msg model =
                     , Cmd.map CacheMsg subCmd
                     )
             in
-            ( model1 |> adjustPresentation context.config
+            ( model1 |> adjustPresentation context
             , cmd1
             , SubNoReturn
             )

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -20,7 +20,7 @@ import Types.Config.FacetAspectConfig as FacetAspect
 import Types.Localization as Localization exposing (Language)
 import Types.Navigation as Navigation exposing (Navigation)
 import Types.Needs
-import Types.Presentation exposing (Presentation(..))
+import Types.Presentation as Presentation exposing (Presentation(..))
 import Types.Route exposing (Route)
 import UI.Article
 import UI.Controls
@@ -114,17 +114,20 @@ updateOnChangedRoute : Context -> Model -> Model
 updateOnChangedRoute context model =
     { model
         | controls = UI.Controls.updateFromRoute context.route model.controls
-        , tree = UI.Tree.expandPresentationFolder model.tree
     }
 
 
 {-| Update the Article to adapt to a changed presentation.
 -}
-updateOnChangedPresentation : Presentation -> Model -> Model
-updateOnChangedPresentation presentation model =
+updateOnChangedPresentation : Context -> Model -> Model
+updateOnChangedPresentation context model =
     { model
         | article =
-            UI.Article.initialModel presentation
+            UI.Article.initialModel context.presentation
+        , tree =
+            UI.Tree.updateOnPresentationFolderId
+                (Presentation.getFolderId context.cache context.presentation)
+                model.tree
     }
 
 

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -20,7 +20,7 @@ import Types.Config.FacetAspectConfig as FacetAspect
 import Types.Localization as Localization exposing (Language)
 import Types.Navigation as Navigation exposing (Navigation)
 import Types.Needs
-import Types.Presentation as Presentation exposing (Presentation(..))
+import Types.Presentation exposing (Presentation(..))
 import Types.Route exposing (Route)
 import UI.Article
 import UI.Controls
@@ -126,7 +126,10 @@ updateOnChangedPresentation context model =
             UI.Article.initialModel context.presentation
         , tree =
             UI.Tree.updateOnPresentationFolderId
-                (Presentation.getFolderId context.cache context.presentation)
+                { config = context.config
+                , cache = context.cache
+                , presentation = context.presentation
+                }
                 model.tree
     }
 

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -174,9 +174,10 @@ viewFolderTree context model maybeFolderCounts id =
                         presentationFolderId == Just id
 
                     expanded =
-                        Folder.isRoot folder
-                            || (model.collapsedPresentationFolder /= Just id)
-                            && Cache.Derive.isOnPath context.config context.cache id presentationFolderId
+                        List.member id context.config.toplevelFolderIds
+                            || ((model.collapsedPresentationFolder /= Just id)
+                                    && Cache.Derive.isOnPath context.config context.cache id presentationFolderId
+                               )
                 in
                 [ Html.div
                     [ Html.Events.onClick (Select id) ]

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -61,12 +61,21 @@ type Return
 
 {-| The model represents the UI state of the tree.
 
-By default, the presentation folder is shown in expanded state.
-If the user clicks (message `Select`) on the presentation folder we show it in collapsed state.
-If later the presentation folder changes, then we want to show it as expanded again.
+Some notes on state management:
 
-For tracking the necessary state we use `latestPresentationFolderId` and
-`userCollapsedPresentationFolder` here in the UI model.
+Selection of the tree nodes to be shown is basically informed by the context,
+notably by the current presentation folder.
+However, the expansion state of the current presentation folder if managed as a local UI state.
+
+By default, the presentation folder is shown in expanded state.
+If the user clicks on the presentation folder we show it in collapsed state.
+If later the presentation folder changes or the user clicks the collapsed folder a second time,
+then we show it in expanded state again.
+
+For tracking the necessary state we use these fields as the local UI state:
+
+  - `latestPresentationFolderId`, which is set in `updateOnPresentationFolderId`
+  - `userCollapsedPresentationFolder`, which may be modified in `update` and in `updateOnPresentationFolderId`
 
 -}
 type alias Model =

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -92,6 +92,7 @@ initialModel =
 needs : Context -> Model -> Cache.Needs
 needs context model =
     getPresentationFolderId context
+        |> Maybe.Extra.orElse (List.head context.config.toplevelFolderIds)
         |> Cache.Derive.getPathAsFarAsCached context.config context.cache
         |> Cache.NeedSubfolders
         |> Types.Needs.atomic

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -59,7 +59,15 @@ type Return
     | UserSelection FolderId
 
 
-{-| -}
+{-| The model represents the UI state of the tree.
+
+By default, the presentation folder is shown in expanded state.
+If the user clicks (message `Select`) on the presentation folder we show it in collapsed state.
+If later the presentation folder changes, then we want to show it as expanded again.
+
+For tracking the collapsed state we use `collapsedPresentationFolder` here in the UI model.
+
+-}
 type alias Model =
     { collapsedPresentationFolder : Maybe FolderId
     }


### PR DESCRIPTION
- Fix expansion state management of presentation folder in tree:  
The presentation folder should not be re-expanded on each arbitrary route change.
Rather it should be re-expanded if the presentation folder is changed.
- Specify expansion state of toplevel folders on presentations without a folder:  
If there is exactly one toplevel folder, it will be displayed expanded by default.  
If there is more than one toplevel folder, they will be displayed collapsed by default.
- Tree needs subfolders of first toplevel folder on presentations without a folder
