### PR TITLE
Use a restricted database user role for accessing API data

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,11 +31,12 @@ Minimum required version is 10.
 
 ### Configuration Variables
 
-We use environment variables to configure the database name and the database user.
+We use environment variables to configure the database name and the relevant database users.
 
 ```sh
 $ export MEDIATUM_DATABASE_NAME="mediatum"
 $ export MEDIATUM_DATABASE_USER="mediatum"
+$ export MEDIATUM_DATABASE_USER_VIEW_API="mediatum_view_api"
 ```
 
 ### RUM
@@ -94,10 +95,17 @@ $ npm install
 ## Installation
 
 The new code lives in dedicated schemas as noted above. 
-In order to create those schemas you may have to grant the permission to do so to the database user:
+In order to create those schemas you may have to grant the permission to do so to the database user that is used to build the database application:
 
 ```sh
 $ psql -d $MEDIATUM_DATABASE_NAME -c "GRANT CREATE ON DATABASE $MEDIATUM_DATABASE_NAME TO $MEDIATUM_DATABASE_USER;"
+```
+
+We need a new database user with restricted privileges that will be used to access the API functions.
+Note that to create this user you need the privilege `CREATEROLE`, e.g. as a superuser.
+
+```sh
+$ psql -d $MEDIATUM_DATABASE_NAME -c "CREATE ROLE $MEDIATUM_DATABASE_USER_VIEW_API LOGIN;"
 ```
 
 To submit the new code to a running mediaTUM database execute the SQL and PL/pgSQL code with the appropriate scripts in `bin/`.
@@ -115,6 +123,12 @@ $ bin/preprocess-catch-up
 Preprocessing the fulltext and meta-data to build the FTS index takes some time, e.g. about 60 minutes for a mediaTUM installation with 600000 nodes.
 
 You may drop all changes introduced by this backend via `bin/drop-all`.
+
+You may also want to drop the newly introduced role used for accessing the API:
+
+```sh
+$ psql -d $MEDIATUM_DATABASE_NAME -c "DROP OWNED BY $MEDIATUM_DATABASE_USER_VIEW_API; DROP ROLE $MEDIATUM_DATABASE_USER_VIEW_API;"
+```
 
 ## Running PostGraphile
 

--- a/backend/bin/build-api
+++ b/backend/bin/build-api
@@ -18,4 +18,4 @@ $p src/sql/api/api-folder.sql
 $p src/sql/api/api-document.sql
 $p src/sql/api/api-fts.sql
 $p src/sql/api/api-facets.sql
-
+$p src/sql/api/grant-privileges.sql

--- a/backend/bin/psql-apiuser
+++ b/backend/bin/psql-apiuser
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Run psql and connect to the database as a superuser for maintenance tasks.
+
+
+psql -d $MEDIATUM_DATABASE_NAME -U $MEDIATUM_DATABASE_USER_VIEW_API $*

--- a/backend/bin/start
+++ b/backend/bin/start
@@ -24,7 +24,7 @@ DATABASE_SUPER_USER="postgres"
 node_modules/.bin/postgraphile \
     --host localhost \
     --connection postgres://$DATABASE_SUPER_USER@localhost:5432/$MEDIATUM_DATABASE_NAME \
-    --default-role $MEDIATUM_DATABASE_USER \
+    --default-role $MEDIATUM_DATABASE_USER_VIEW_API \
     --schema api \
     --cors  \
     --export-schema-graphql export/schema-export.graphql \

--- a/backend/src/sql/api/drop.sql
+++ b/backend/src/sql/api/drop.sql
@@ -1,4 +1,3 @@
 
--- Drop all schemas introduced specifically by this backend.
-
+-- Drop all schemas introduced specifically for API access.
 drop schema if exists aux, entity, api CASCADE;

--- a/backend/src/sql/api/grant-privileges.sql
+++ b/backend/src/sql/api/grant-privileges.sql
@@ -1,0 +1,46 @@
+
+-- 
+
+-- We define a user with restricted privileges for API access via postgraphile.
+-- 
+-- Default user `mediatum` does not have the privilege `CREATEROLE`.
+-- So, the role for this user needs to be created by e.g. a superuser.
+-- 
+-- create role mediatum_view_api login;
+
+
+-- Grant all privileges needed when accessing the API.
+
+grant usage on schema
+    mediatum,
+    config,
+    preprocess,
+    entity,
+    aux,
+    api
+    to mediatum_view_api;
+
+grant select on table
+    mediatum.node,
+    mediatum.nodetype,
+    mediatum.noderelation,
+    mediatum.nodemapping,
+    mediatum.node_to_access_rule,
+    mediatum.access_rule
+    to mediatum_view_api;
+
+grant select on table
+    preprocess.ufts,
+    preprocess.aspect
+    to mediatum_view_api;
+
+grant select on all tables in schema
+    config,
+    entity,
+    aux
+    to mediatum_view_api;
+
+grant execute on all functions in schema
+    api,
+    aux
+    to mediatum_view_api;


### PR DESCRIPTION
Postgraphile accesses the database to resolve an API request using a "default role".

For security reasons, we define a new restricted role `mediatum_view_api` to be used as this default role,
which has only the strictly necessary privileges to access the data in question.

See `backend/README.md` for setup instructions.
