### PR TITLE
Facet boxes UI

### DIFF
--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -269,6 +269,10 @@ ul.folder-list ul.folder-list {
   text-decoration: underline;
 }
 
+.folder-head.toplevel {
+  font-weight: bold;
+}
+
 .svg-icon {
   display: inline-block;
   width: 1.5ex;
@@ -364,8 +368,8 @@ ul.folder-list ul.folder-list {
 .facet-special-action .facet-value-text {
   font-style: italic;
 }
-.facet-value-selected .facet-value-text {
-  font-weight: bold;
+.facet-value-selected {
+  color: #a0af00;
 }
 .facet-value-count {
   margin-left: 0.2em;

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -335,8 +335,15 @@ ul.folder-list ul.folder-list {
   background-color: #f7f7f7;
   margin-top: 1ex;
 }
+.facet-head {
+  display: flex;
+}
 .facet-name {
+  padding-left: 0.6em;
   font-weight: bold;
+}
+.facet-body {
+  margin-left: 1.4em;
 }
 .facet-values {
   margin: 0;
@@ -346,7 +353,7 @@ ul.folder-list ul.folder-list {
 .facet-line {
   display: flex;
 }
-.facet-clickable:hover .facet-value-text {
+.facet-clickable:hover .facet-value-text, .facet-clickable:hover .facet-name {
   text-decoration: underline;
 }
 .facet-value-text {

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -339,24 +339,23 @@ ul.folder-list ul.folder-list {
   font-weight: bold;
 }
 .facet-values {
-  max-height: 13.5ex;
-  overflow-y: auto;
-}
-.facet-values ul {
   margin: 0;
   padding: 0;
   list-style: none;
 }
-.facet-value-line {
+.facet-line {
   display: flex;
 }
-.facet-value-line:hover {
+.facet-clickable:hover .facet-value-text {
   text-decoration: underline;
 }
 .facet-value-text {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.facet-special-action .facet-value-text {
+  font-style: italic;
 }
 .facet-value-selected .facet-value-text {
   font-weight: bold;

--- a/frontend/src/elm/Types/Config.elm
+++ b/frontend/src/elm/Types/Config.elm
@@ -39,6 +39,7 @@ type alias Config =
     , maxLimit : Int
     , defaultSorting : Selection.Sorting
     , numberOfFacetValues : Int
+    , numberOfFacetValuesShortList : Int
     , ftsAspects : List FtsAspectConfig
     , facetAspects : List FacetAspectConfig
     , masks : MasksConfig
@@ -57,6 +58,7 @@ init =
     , maxLimit = 1000
     , defaultSorting = Selection.ByRank
     , numberOfFacetValues = 20
+    , numberOfFacetValuesShortList = 5
     , ftsAspects = []
     , facetAspects = []
     , masks = MasksConfig.init

--- a/frontend/src/elm/UI/Facets.elm
+++ b/frontend/src/elm/UI/Facets.elm
@@ -182,8 +182,8 @@ viewFacetSelection config aspect selectedValue maybeCount =
         [ Html.span
             [ Html.Attributes.class "facet-value-text" ]
             [ Localization.text config
-                { en = "<< All"
-                , de = "<< zurück"
+                { en = "<< Any"
+                , de = "<< beliebig"
                 }
             ]
         ]


### PR DESCRIPTION
- Limit the number of facet values shown per default to 5 ("short list")
- User can click on "more" to show up to 20 values ("long list")
- The value list of a facet box is now collapsible
- The header line of a facet box is rendered in bold and shows an expando icon
- A selected facet value is rendered in a spot color
- The tree view adopts the appearance of the facet boxes (toplevel folder in bold, selected folder in spot color)