### PR TITLE
Layout of search matching indicator

### DIFF
--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -257,8 +257,26 @@ a.document {
 a.document:hover {
   text-decoration: unset;
 }
-.document .metadatatype {
+.document .header {
+  display: flex;
+  align-items: center;
+}
+.document .header .header-left, .document .header .header-right {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.document .header-left {
+  flex: 0 1 auto;
   color: var(--color-primary);
+}
+.document .header-right {
+  margin-left: 1em;
+  flex: 1 1 15%;
+  height: 100%;
+  text-align: right;
+  font-size: 80%;
+  color: var(--color-text-light);
 }
 .listing .attributes {
   margin-left: 2em;

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -215,17 +215,17 @@ viewSearchMatching config =
 
                 ( True, False ) ->
                     { en = "Search term found in metadata"
-                    , de = "Suchbegriff in Metadaten gefunden"
+                    , de = "Fundstellen in Metadaten"
                     }
 
                 ( False, True ) ->
                     { en = "Search term found in fulltext"
-                    , de = "Suchbegriff in Volltext gefunden"
+                    , de = "Fundstellen in Volltext"
                     }
 
                 ( True, True ) ->
                     { en = "Search term found in metadata and fulltext"
-                    , de = "Suchbegriff in Metadaten und Volltext gefunden"
+                    , de = "Fundstellen in Metadaten und Volltext"
                     }
         )
         >> Localization.text config

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -205,37 +205,52 @@ viewDocument context number document =
 viewSearchMatching : Config -> Maybe Document.SearchMatching -> Html msg
 viewSearchMatching config maybeSearchMatching =
     let
-        notice =
+        ( noticeShort, noticeLong ) =
             case maybeSearchMatching of
                 Nothing ->
-                    ""
+                    ( "", "" )
 
                 Just { attributes, fulltext } ->
-                    Localization.string config <|
+                    Tuple.mapBoth
+                        (Localization.string config)
+                        (Localization.string config)
+                    <|
                         case ( attributes, fulltext ) of
                             ( False, False ) ->
-                                { en = "", de = "" }
+                                ( { en = "", de = "" }, { en = "", de = "" } )
 
                             ( True, False ) ->
-                                { en = "Search term found in metadata"
-                                , de = "Fundstellen in Metadaten"
-                                }
+                                ( { en = "Search term found in metadata"
+                                  , de = "Fundstellen in Metadaten"
+                                  }
+                                , { en = "Search term found in metadata"
+                                  , de = "Suchbegriff in Metadaten gefunden"
+                                  }
+                                )
 
                             ( False, True ) ->
-                                { en = "Search term found in fulltext"
-                                , de = "Fundstellen in Volltext"
-                                }
+                                ( { en = "Search term found in fulltext"
+                                  , de = "Fundstellen in Volltext"
+                                  }
+                                , { en = "Search term found in fulltext"
+                                  , de = "Suchbegriff in Volltext gefunden"
+                                  }
+                                )
 
                             ( True, True ) ->
-                                { en = "Search term found in metadata and fulltext"
-                                , de = "Fundstellen in Metadaten und Volltext"
-                                }
+                                ( { en = "Search term found in metadata and fulltext"
+                                  , de = "Fundstellen in Metadaten und Volltext"
+                                  }
+                                , { en = "Search term found in metadata and fulltext"
+                                  , de = "Suchbegriff in Metadaten und Volltext gefunden"
+                                  }
+                                )
     in
     Html.span
         [ Html.Attributes.class "found-locations"
-        , Html.Attributes.title notice
+        , Html.Attributes.title noticeLong
         ]
-        [ Html.text notice ]
+        [ Html.text noticeShort ]
 
 
 keys :

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -189,9 +189,7 @@ viewDocument context number document =
                     [ Html.text document.metadatatypeName ]
                 ]
             , Html.div [ Html.Attributes.class "header-right" ]
-                [ Html.span [ Html.Attributes.class "found-locations" ]
-                    [ viewSearchMatching context.config document.searchMatching ]
-                ]
+                [ viewSearchMatching context.config document.searchMatching ]
             ]
         , Html.div
             [ Html.Attributes.class "attributes"
@@ -205,30 +203,39 @@ viewDocument context number document =
 
 
 viewSearchMatching : Config -> Maybe Document.SearchMatching -> Html msg
-viewSearchMatching config =
-    Maybe.Extra.unwrap
-        { en = "", de = "" }
-        (\{ attributes, fulltext } ->
-            case ( attributes, fulltext ) of
-                ( False, False ) ->
-                    { en = "", de = "" }
+viewSearchMatching config maybeSearchMatching =
+    let
+        notice =
+            case maybeSearchMatching of
+                Nothing ->
+                    ""
 
-                ( True, False ) ->
-                    { en = "Search term found in metadata"
-                    , de = "Fundstellen in Metadaten"
-                    }
+                Just { attributes, fulltext } ->
+                    Localization.string config <|
+                        case ( attributes, fulltext ) of
+                            ( False, False ) ->
+                                { en = "", de = "" }
 
-                ( False, True ) ->
-                    { en = "Search term found in fulltext"
-                    , de = "Fundstellen in Volltext"
-                    }
+                            ( True, False ) ->
+                                { en = "Search term found in metadata"
+                                , de = "Fundstellen in Metadaten"
+                                }
 
-                ( True, True ) ->
-                    { en = "Search term found in metadata and fulltext"
-                    , de = "Fundstellen in Metadaten und Volltext"
-                    }
-        )
-        >> Localization.text config
+                            ( False, True ) ->
+                                { en = "Search term found in fulltext"
+                                , de = "Fundstellen in Volltext"
+                                }
+
+                            ( True, True ) ->
+                                { en = "Search term found in metadata and fulltext"
+                                , de = "Fundstellen in Metadaten und Volltext"
+                                }
+    in
+    Html.span
+        [ Html.Attributes.class "found-locations"
+        , Html.Attributes.title notice
+        ]
+        [ Html.text notice ]
 
 
 keys :

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -181,10 +181,16 @@ viewDocument context number document =
             context
             (Navigation.ShowDocument context.selection.scope document.id)
         ]
-        [ Html.div [ Html.Attributes.class "metadatatype" ]
-            [ Html.span [ Html.Attributes.class "result-number" ]
-                [ Html.text <| String.fromInt number ++ ". "
-                , Html.text document.metadatatypeName
+        [ Html.div [ Html.Attributes.class "header" ]
+            [ Html.div [ Html.Attributes.class "header-left" ]
+                [ Html.span [ Html.Attributes.class "result-number" ]
+                    [ Html.text <| String.fromInt number ++ ". " ]
+                , Html.span [ Html.Attributes.class "metadatatype" ]
+                    [ Html.text document.metadatatypeName ]
+                ]
+            , Html.div [ Html.Attributes.class "header-right" ]
+                [ Html.span [ Html.Attributes.class "found-locations" ]
+                    [ viewSearchMatching context.config document.searchMatching ]
                 ]
             ]
         , Html.div
@@ -195,7 +201,6 @@ viewDocument context number document =
                 viewAttribute
                 document.attributes
             )
-        , viewSearchMatching context.config document.searchMatching
         ]
 
 


### PR DESCRIPTION
Listing view:
- Indicate found locations on first line instead of requiring an extra line.
- Show a tooltip on hovering over the notice.
- Use a shorter wording for the in-place indicator and a longer, more descriptive one for the tooltip.