### PR TITLE
Amend displayed metadata of documents

### DIFF
--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -261,11 +261,6 @@ a.document:hover {
   display: flex;
   align-items: center;
 }
-.document .header .header-left, .document .header .header-right {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
 .document .header-left {
   flex: 0 1 auto;
   color: var(--color-primary);
@@ -274,6 +269,9 @@ a.document:hover {
   margin-left: 1em;
   flex: 1 1 15%;
   height: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   text-align: right;
   font-size: 80%;
   color: var(--color-text-light);

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -278,6 +278,25 @@ a.document:hover {
   font-size: 80%;
   color: var(--color-text-light);
 }
+.listing .document {
+  display: flex;
+}
+.listing .document .thumbnail {
+  flex: 0 1 auto;
+  margin-right: 1em;
+  min-width: 3em;
+  max-width: 30%;
+}
+.listing .document .thumbnail img {
+  width: 100%;
+  height: auto;
+  max-width: 128px;
+  max-height: 128px;
+}
+.listing .document .description {
+  flex: 1 1 0;
+  width: 15em;
+}
 .listing .attributes {
   margin-left: 2em;
 }

--- a/frontend/src/elm/Api/Fragments.elm
+++ b/frontend/src/elm/Api/Fragments.elm
@@ -656,6 +656,8 @@ decoderAttributeList =
                             (Entities.Markup.parse
                                 (Entities.Markup.SpanClass "unparsable")
                             )
+                        |> Json.Decode.map
+                            Entities.Markup.fixSpacesAfterSeparators
                         |> Json.Decode.maybe
                     )
                 )

--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -2,6 +2,7 @@ module Constants exposing
     ( apiUrl, graphqlOperationNamePrefix
     , incrementLimitOnLoadMore
     , maxAttributeLengthInListingView
+    , contentServerUrls
     )
 
 {-| Configurable values
@@ -9,8 +10,11 @@ module Constants exposing
 @docs apiUrl, graphqlOperationNamePrefix
 @docs incrementLimitOnLoadMore
 @docs maxAttributeLengthInListingView
+@docs contentServerUrls
 
 -}
+
+import Types.Id as Id
 
 
 {-| Endpoint for backend's GraphQL service.
@@ -50,3 +54,22 @@ incrementLimitOnLoadMore limit =
 maxAttributeLengthInListingView : Int
 maxAttributeLengthInListingView =
     200
+
+
+{-| Content like document files and thumbnails are provided by a separate server.
+
+This value is a record of URL building functions to this server.
+
+-}
+contentServerUrls :
+    { thumbnail : Id.DocumentId -> String
+    , presentation : Id.DocumentId -> String
+    }
+contentServerUrls =
+    let
+        appendId base id =
+            base ++ Id.toString id
+    in
+    { thumbnail = "https://mediatum.ub.tum.de/thumbs/" |> appendId
+    , presentation = "https://mediatum.ub.tum.de/thumb2/" |> appendId
+    }

--- a/frontend/src/elm/Entities/Markup.elm
+++ b/frontend/src/elm/Entities/Markup.elm
@@ -3,11 +3,11 @@ module Entities.Markup exposing
     , FlagUnparsable(..)
     , parse
     , empty, plainText
-    , normalizeYear
+    , normalizeYear, normalizeYearMonth
     , isEmpty
     , trim, view
     , toHtmlString
-    , fixSpacesAfterSeparators
+    , fixSpacesAfterSeparators, normalizeYearMonthDay
     )
 
 {-|
@@ -16,7 +16,8 @@ module Entities.Markup exposing
 @docs FlagUnparsable
 @docs parse
 @docs empty, plainText
-@docs normalizeYear, fixSpaceInSemicolonSeparatedList
+@docs normalizeYear, normalizeYearMonth
+@docs fixSpaceInSemicolonSeparatedList
 @docs isEmpty
 @docs trim, view
 @docs toHtmlString
@@ -130,6 +131,31 @@ normalizeYear markup =
     Markup
         [ Html.Parser.Text
             (plainText markup |> String.left 4)
+        ]
+
+
+{-| Attribute "yearmonth" are mostly formatted as "2020-03-00T00:00:00".
+For a nicer display we take just the first segment and only the first 7 characters of it.
+
+    normalizeYear (parse "<span>2020</span>-03-00T00:00:00")
+        == parse "2020-03"
+
+Note: Currently we don't preserve the markup structure. This should get implemented someday!
+
+-}
+normalizeYearMonth : Markup -> Markup
+normalizeYearMonth markup =
+    Markup
+        [ Html.Parser.Text
+            (plainText markup |> String.left 7)
+        ]
+
+
+normalizeYearMonthDay : Markup -> Markup
+normalizeYearMonthDay markup =
+    Markup
+        [ Html.Parser.Text
+            (plainText markup |> String.left 10)
         ]
 
 

--- a/frontend/src/elm/Types/Navigation.elm
+++ b/frontend/src/elm/Types/Navigation.elm
@@ -29,6 +29,7 @@ import Types.Selection exposing (FtsFilters, GlobalFts, Sorting)
 type Navigation
     = ListOfNavigations (List Navigation)
     | ShowDocument FolderId DocumentId
+    | ShowDocumentPermalink DocumentId
     | ShowListingWithoutDocument
     | ShowListingWithFolder FolderId
     | ShowListingWithSearchAndFtsFilter GlobalFts FtsFilters Sorting
@@ -82,6 +83,9 @@ alterRoute config cache navigation route =
                         (folderId |> Id.asNodeId)
                         (documentId |> Id.asNodeId)
             }
+
+        ShowDocumentPermalink documentId ->
+            Route.initDocumentWithoutFolder config documentId
 
         ShowListingWithoutDocument ->
             { route

--- a/frontend/src/elm/Types/Route.elm
+++ b/frontend/src/elm/Types/Route.elm
@@ -3,7 +3,7 @@ module Types.Route exposing
     , RoutePath(..)
     , RouteParameters
     , initHome
-    , initDocumentInFolder
+    , initDocumentInFolder, initDocumentWithoutFolder
     , sanitize
     )
 
@@ -16,7 +16,7 @@ Parsing URLs and stringifying routes are defined in [`Types.Route.Url`](Types-Ro
 @docs RouteParameters
 
 @docs initHome
-@docs initDocumentInFolder
+@docs initDocumentInFolder, initDocumentWithoutFolder
 
 @docs sanitize
 
@@ -68,6 +68,15 @@ initHome config =
 initDocumentInFolder : Config -> FolderId -> DocumentId -> Route
 initDocumentInFolder config folderId documentId =
     { path = TwoIds (Types.Id.asNodeId folderId) (Types.Id.asNodeId documentId)
+    , parameters = emptyParameters config
+    }
+
+
+{-| A route to a document without a folder, without any further parameters.
+-}
+initDocumentWithoutFolder : Config -> DocumentId -> Route
+initDocumentWithoutFolder config documentId =
+    { path = OneId (Types.Id.asNodeId documentId)
     , parameters = emptyParameters config
     }
 

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -34,6 +34,7 @@ import Types exposing (DocumentIdFromSearch)
 import Types.Config as Config exposing (Config)
 import Types.Config.MasksConfig as MasksConfig
 import Types.Localization as Localization
+import Types.Navigation as Navigation
 import Types.Route exposing (Route)
 import UI.Icons
 import UI.Widgets.Breadcrumbs
@@ -107,7 +108,19 @@ view context model =
 viewDocument : Context -> Model -> Document -> Residence -> Html Msg
 viewDocument context model document residence =
     Html.div []
-        [ Html.div
+        [ Html.div [ Html.Attributes.class "permalink" ]
+            [ Html.a
+                [ Navigation.alterRouteHref
+                    context
+                    (Navigation.ShowDocumentPermalink document.id)
+                ]
+                [ Localization.text context.config
+                    { en = "Permanent link"
+                    , de = "Dauerhafter Link"
+                    }
+                ]
+            ]
+        , Html.div
             [ Html.Attributes.class "thumbnail" ]
             [ Html.img
                 [ Html.Attributes.src

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -36,7 +36,6 @@ import Types.Config.MasksConfig as MasksConfig
 import Types.Localization as Localization
 import Types.Navigation as Navigation
 import Types.Route exposing (Route)
-import Types.Route.Url
 import UI.Icons
 import UI.Widgets.Breadcrumbs
 import Utils.Html
@@ -109,23 +108,17 @@ view context model =
 viewDocument : Context -> Model -> Document -> Residence -> Html Msg
 viewDocument context model document residence =
     Html.div []
-        [ let
-            permalinkUrl =
-                Navigation.alterRoute
-                    context.config
-                    context.cache
+        [ Html.div [ Html.Attributes.class "permalink" ]
+            [ Html.a
+                [ Navigation.alterRouteHref
+                    context
                     (Navigation.ShowDocumentPermalink document.id)
-                    context.route
-                    |> Types.Route.Url.toString context.config
-          in
-          Html.div [ Html.Attributes.class "permalink" ]
-            [ Localization.text context.config
-                { en = "Permanent link: "
-                , de = "Dauerhafter Link: "
-                }
-            , Html.a
-                [ Html.Attributes.href permalinkUrl ]
-                [ Html.text permalinkUrl ]
+                ]
+                [ Localization.text context.config
+                    { en = "Permanent link"
+                    , de = "Dauerhafter Link"
+                    }
+                ]
             ]
         , Html.div
             [ Html.Attributes.class "thumbnail" ]

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -206,24 +206,33 @@ viewAttribute attribute =
 
 viewResidence : Context -> Residence -> Html msg
 viewResidence context residence =
-    Html.div
-        [ Html.Attributes.class "residence" ]
-        [ Html.div
-            [ Html.Attributes.class "title" ]
-            [ Localization.text context.config
-                { en = "Occurrences:"
-                , de = "Vorkommen:"
-                }
+    let
+        residenceLimitedToToplevelFolders : Residence
+        residenceLimitedToToplevelFolders =
+            Residence.limitToToplevelFolders context.config residence
+    in
+    if List.isEmpty residenceLimitedToToplevelFolders then
+        Html.text ""
+
+    else
+        Html.div
+            [ Html.Attributes.class "residence" ]
+            [ Html.div
+                [ Html.Attributes.class "title" ]
+                [ Localization.text context.config
+                    { en = "Occurrences:"
+                    , de = "Vorkommen:"
+                    }
+                ]
+            , Html.ul [] <|
+                List.map
+                    (\lineage ->
+                        Html.li []
+                            [ lineage
+                                |> List.Nonempty.toList
+                                |> Just
+                                |> UI.Widgets.Breadcrumbs.view context
+                            ]
+                    )
+                    residenceLimitedToToplevelFolders
             ]
-        , Html.ul [] <|
-            List.map
-                (\lineage ->
-                    Html.li []
-                        [ lineage
-                            |> List.Nonempty.toList
-                            |> Just
-                            |> UI.Widgets.Breadcrumbs.view context
-                        ]
-                )
-                (Residence.limitToToplevelFolders context.config residence)
-        ]

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -21,6 +21,7 @@ module UI.Article.Details exposing
 -}
 
 import Cache exposing (Cache)
+import Constants
 import Entities.Document as Document exposing (Document)
 import Entities.Markup exposing (Markup)
 import Entities.Residence as Residence exposing (Residence)
@@ -31,6 +32,7 @@ import RemoteData
 import Types exposing (DocumentIdFromSearch)
 import Types.Config as Config exposing (Config)
 import Types.Config.MasksConfig as MasksConfig
+import Types.Id as Id
 import Types.Localization as Localization
 import Types.Route exposing (Route)
 import UI.Icons
@@ -105,7 +107,15 @@ view context model =
 viewDocument : Context -> Model -> Document -> Residence -> Html Msg
 viewDocument context model document residence =
     Html.div []
-        [ Html.div [ Html.Attributes.class "header" ]
+        [ Html.div
+            [ Html.Attributes.class "thumbnail" ]
+            [ Html.img
+                [ Html.Attributes.src
+                    (Constants.contentServerUrls.presentation document.id)
+                ]
+                []
+            ]
+        , Html.div [ Html.Attributes.class "header" ]
             [ Html.div [ Html.Attributes.class "metadatatype" ]
                 [ Html.text document.metadatatypeName ]
             ]

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -208,7 +208,7 @@ keys =
     in
     { year = regex "year"
     , yearmonth = regex "yearmonth"
-    , date = regex "publicationdate"
+    , date = regex "date"
     }
 
 

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -200,6 +200,7 @@ keys :
     { year : Regex.Regex
     , yearmonth : Regex.Regex
     , date : Regex.Regex
+    , wwwAddress : Regex.Regex
     }
 keys =
     let
@@ -209,6 +210,7 @@ keys =
     { year = regex "year"
     , yearmonth = regex "yearmonth"
     , date = regex "date"
+    , wwwAddress = regex "www-address"
     }
 
 
@@ -234,6 +236,9 @@ viewAttribute attribute =
 
                                 else if isField keys.date then
                                     Markup.normalizeYearMonthDay
+
+                                else if isField keys.wwwAddress then
+                                    Markup.renderWwwAddress
 
                                 else
                                     identity

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -36,6 +36,7 @@ import Types.Config.MasksConfig as MasksConfig
 import Types.Localization as Localization
 import Types.Navigation as Navigation
 import Types.Route exposing (Route)
+import Types.Route.Url
 import UI.Icons
 import UI.Widgets.Breadcrumbs
 import Utils.Html
@@ -108,17 +109,23 @@ view context model =
 viewDocument : Context -> Model -> Document -> Residence -> Html Msg
 viewDocument context model document residence =
     Html.div []
-        [ Html.div [ Html.Attributes.class "permalink" ]
-            [ Html.a
-                [ Navigation.alterRouteHref
-                    context
+        [ let
+            permalinkUrl =
+                Navigation.alterRoute
+                    context.config
+                    context.cache
                     (Navigation.ShowDocumentPermalink document.id)
-                ]
-                [ Localization.text context.config
-                    { en = "Permanent link"
-                    , de = "Dauerhafter Link"
-                    }
-                ]
+                    context.route
+                    |> Types.Route.Url.toString context.config
+          in
+          Html.div [ Html.Attributes.class "permalink" ]
+            [ Localization.text context.config
+                { en = "Permanent link: "
+                , de = "Dauerhafter Link: "
+                }
+            , Html.a
+                [ Html.Attributes.href permalinkUrl ]
+                [ Html.text permalinkUrl ]
             ]
         , Html.div
             [ Html.Attributes.class "thumbnail" ]

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -242,7 +242,10 @@ viewAttribute attribute =
                 Html.tr
                     [ Html.Attributes.class "attribute" ]
                     [ Html.td
-                        [ Html.Attributes.title attribute.field ]
+                        [ -- For developing and debugging purposes:
+                          -- Attach the field name as a data attribute to the DOM node
+                          Html.Attributes.attribute "data-mediatum-field" attribute.field
+                        ]
                         [ Html.text attribute.name ]
                     , Html.td []
                         (Markup.view fixedValue)

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -29,13 +29,12 @@ import Entities.PageSequence as PageSequence exposing (PageSequence)
 import Html exposing (Html)
 import Html.Attributes
 import Html.Events
-import Maybe.Extra
 import Regex
 import RemoteData
 import Types.ApiData exposing (ApiData)
 import Types.Config as Config exposing (Config)
 import Types.Config.MasksConfig as MasksConfig
-import Types.Id exposing (DocumentId)
+import Types.Id as Id exposing (DocumentId)
 import Types.Localization as Localization
 import Types.Navigation as Navigation exposing (Navigation)
 import Types.Route exposing (Route)
@@ -181,24 +180,34 @@ viewDocument context number document =
             context
             (Navigation.ShowDocument context.selection.scope document.id)
         ]
-        [ Html.div [ Html.Attributes.class "header" ]
-            [ Html.div [ Html.Attributes.class "header-left" ]
-                [ Html.span [ Html.Attributes.class "result-number" ]
-                    [ Html.text <| String.fromInt number ++ ". " ]
-                , Html.span [ Html.Attributes.class "metadatatype" ]
-                    [ Html.text document.metadatatypeName ]
+        [ Html.div
+            [ Html.Attributes.class "thumbnail" ]
+            [ Html.img
+                [ Html.Attributes.src
+                    (Constants.contentServerUrls.thumbnail document.id)
                 ]
-            , Html.div [ Html.Attributes.class "header-right" ]
-                [ viewSearchMatching context.config document.searchMatching ]
+                []
             ]
-        , Html.div
-            [ Html.Attributes.class "attributes"
-            , Html.Events.onClick (SelectDocument document.id)
+        , Html.div [ Html.Attributes.class "description" ]
+            [ Html.div [ Html.Attributes.class "header" ]
+                [ Html.div [ Html.Attributes.class "header-left" ]
+                    [ Html.span [ Html.Attributes.class "result-number" ]
+                        [ Html.text <| String.fromInt number ++ ". " ]
+                    , Html.span [ Html.Attributes.class "metadatatype" ]
+                        [ Html.text document.metadatatypeName ]
+                    ]
+                , Html.div [ Html.Attributes.class "header-right" ]
+                    [ viewSearchMatching context.config document.searchMatching ]
+                ]
+            , Html.div
+                [ Html.Attributes.class "attributes"
+                , Html.Events.onClick (SelectDocument document.id)
+                ]
+                (List.map
+                    viewAttribute
+                    document.attributes
+                )
             ]
-            (List.map
-                viewAttribute
-                document.attributes
-            )
         ]
 
 

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -303,6 +303,9 @@ viewAttribute attribute =
                                 && not (isField keys.congressOrJournal)
                           )
                         ]
+                    , -- For developing and debugging purposes:
+                      -- Attach the field name as a data attribute to the DOM node
+                      Html.Attributes.attribute "data-mediatum-field" attribute.field
                     ]
                     (let
                         markup =

--- a/frontend/tests/Tests/Entities/Markup.elm
+++ b/frontend/tests/Tests/Entities/Markup.elm
@@ -177,18 +177,134 @@ all =
                 normalizeYear
                     >> plainText
                     >> Expect.equal "2020"
-            , testText "<span>2020</span>-00-00T00:00:00" <|
+            , testText "2020-00-00T00:00:00Z" <|
                 normalizeYear
                     >> plainText
                     >> Expect.equal "2020"
-            , testText "<span>2020-00-00</span>T00:00:00" <|
+            , testText "2020-00-00" <|
                 normalizeYear
                     >> plainText
                     >> Expect.equal "2020"
-            , testText "2020-00-<span>00</span>T00:00:00" <|
+            , testText "2020-11-22T11:22:33" <|
                 normalizeYear
                     >> plainText
                     >> Expect.equal "2020"
+            , testText "2020-00-00, 2021-00-00" <|
+                normalizeYear
+                    >> plainText
+                    >> Expect.equal "2020, 2021"
+            , testText "abc<span>2020-00-00T00:00:00</span>def" <|
+                normalizeYear
+                    >> toHtmlString
+                    >> Expect.equal "abc<span>2020</span>def"
+            , testText "2020-00-00T00:00:00missing word boundary" <|
+                normalizeYear
+                    >> plainText
+                    >> Expect.equal "2020-00-00T00:00:00missing word boundary"
+            , testText "2020-00-00missing word boundary" <|
+                normalizeYear
+                    >> plainText
+                    >> Expect.equal "2020-00-00missing word boundary"
+            , testText "missing word boundary2020-00-00T00:00:00" <|
+                normalizeYear
+                    >> plainText
+                    >> Expect.equal "missing word boundary2020-00-00T00:00:00"
+            , testText "missing word boundary2020-00-00" <|
+                normalizeYear
+                    >> plainText
+                    >> Expect.equal "missing word boundary2020-00-00"
+            ]
+        , describe "normalizeYearMonth"
+            [ testText "" <|
+                normalizeYearMonth
+                    >> plainText
+                    >> Expect.equal ""
+            , testText "2020-11-00T00:00:00" <|
+                normalizeYearMonth
+                    >> plainText
+                    >> Expect.equal "2020-11"
+            , testText "2020-11-00T00:00:00Z" <|
+                normalizeYearMonth
+                    >> plainText
+                    >> Expect.equal "2020-11"
+            , testText "2020-11-00" <|
+                normalizeYearMonth
+                    >> plainText
+                    >> Expect.equal "2020-11"
+            , testText "2020-11-22T11:22:33" <|
+                normalizeYearMonth
+                    >> plainText
+                    >> Expect.equal "2020-11"
+            , testText "2020-11-00, 2021-12-00" <|
+                normalizeYearMonth
+                    >> plainText
+                    >> Expect.equal "2020-11, 2021-12"
+            , testText "abc<span>2020-11-00T00:00:00</span>def" <|
+                normalizeYearMonth
+                    >> toHtmlString
+                    >> Expect.equal "abc<span>2020-11</span>def"
+            , testText "2020-11-00T00:00:00missing word boundary" <|
+                normalizeYearMonth
+                    >> plainText
+                    >> Expect.equal "2020-11-00T00:00:00missing word boundary"
+            , testText "2020-11-00missing word boundary" <|
+                normalizeYearMonth
+                    >> plainText
+                    >> Expect.equal "2020-11-00missing word boundary"
+            , testText "missing word boundary2020-11-00T00:00:00" <|
+                normalizeYearMonth
+                    >> plainText
+                    >> Expect.equal "missing word boundary2020-11-00T00:00:00"
+            , testText "missing word boundary2020-11-00" <|
+                normalizeYearMonth
+                    >> plainText
+                    >> Expect.equal "missing word boundary2020-11-00"
+            ]
+        , describe "normalizeYearMonthDay"
+            [ testText "" <|
+                normalizeYearMonthDay
+                    >> plainText
+                    >> Expect.equal ""
+            , testText "2020-11-22T00:00:00" <|
+                normalizeYearMonthDay
+                    >> plainText
+                    >> Expect.equal "2020-11-22"
+            , testText "2020-11-22T00:00:00Z" <|
+                normalizeYearMonthDay
+                    >> plainText
+                    >> Expect.equal "2020-11-22"
+            , testText "2020-11-22" <|
+                normalizeYearMonthDay
+                    >> plainText
+                    >> Expect.equal "2020-11-22"
+            , testText "2020-11-22T11:22:33" <|
+                normalizeYearMonthDay
+                    >> plainText
+                    >> Expect.equal "2020-11-22"
+            , testText "2020-11-22, 2021-12-24" <|
+                normalizeYearMonthDay
+                    >> plainText
+                    >> Expect.equal "2020-11-22, 2021-12-24"
+            , testText "abc<span>2020-11-22T00:00:00</span>def" <|
+                normalizeYearMonthDay
+                    >> toHtmlString
+                    >> Expect.equal "abc<span>2020-11-22</span>def"
+            , testText "2020-11-22T00:00:00missing word boundary" <|
+                normalizeYearMonthDay
+                    >> plainText
+                    >> Expect.equal "2020-11-22T00:00:00missing word boundary"
+            , testText "2020-11-22missing word boundary" <|
+                normalizeYearMonthDay
+                    >> plainText
+                    >> Expect.equal "2020-11-22missing word boundary"
+            , testText "missing word boundary2020-11-22T00:00:00" <|
+                normalizeYearMonthDay
+                    >> plainText
+                    >> Expect.equal "missing word boundary2020-11-22T00:00:00"
+            , testText "missing word boundary2020-11-22" <|
+                normalizeYearMonthDay
+                    >> plainText
+                    >> Expect.equal "missing word boundary2020-11-22"
             ]
         ]
 


### PR DESCRIPTION
- Work around to show author name of dissertations in details
- Show thumbnails in listing and details view
- Use word wrapping in metadatatype
- Don't show occurences if there is no residence within the configured tree
- Insert missing spaces in lists of persons
- Normalize dates in details view
- Use regexes for normalizing various date formats; add tests
- Apply normalizeYearMonthDay on all fields that have "date" in their name
- Save the fieldname  in DOM Attribute "data-mediatum-field"
- Render link content in field "www-address"
- Show permalink in details view