### PR TITLE
Layout of controls in upper navigation

### DIFF
--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -244,6 +244,9 @@ button.text-button {
 .filters-bar .fts-aspect-buttons .separator {
   color: var(--color-text-light);
 }
+.filters-bar.facet-controls {
+  min-height: 5.7ex;
+}
 .filter-form {
   display: inline-block;
 }

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -74,14 +74,14 @@ body, input {
   color: var(--color-primary);
 }
 
-a, .text-button {
+a, button.text-button {
   color: var(--color-primary-lighter);
   text-decoration: none;
 }
-.text-button.text-button-negligible {
+button.text-button.text-button-negligible {
   color: var(--color-text-light);
 }
-a:hover, .text-button:hover {
+a:hover, button.text-button:hover {
   text-decoration: underline;
 }
 
@@ -225,11 +225,20 @@ input.hide-clear[type=search]::-ms-reveal {
   width: 0;
   height: 0; 
 }
+button {
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+}
+button.text-button {
+  font-size: unset;
+  background-color: unset;
+  border: 0;
+  padding: 0;
+}
 
 .filters-bar {
   margin: 1rem 0;
 }
-.filters-bar .fts-aspect-buttons .text-button {
+.filters-bar .fts-aspect-buttons button.text-button {
   margin: 0 0.10rem;
 }
 .filters-bar .fts-aspect-buttons .separator {
@@ -245,10 +254,10 @@ input.hide-clear[type=search]::-ms-reveal {
 button:not(:disabled):not(.disabled) {
   cursor: pointer; 
 }
-button:disabled, button.disabled {
+button.visual-button:disabled, button.visual-button.disabled {
   opacity: .65;
 }
-button, select {
+button.visual-button, select {
   user-select: none;
   border: 1px solid;
   padding: .375rem .75rem;
@@ -260,12 +269,13 @@ button, select {
   background-color: var(--color-button-background);
   border-color: var(--color-input-border);
 }
-button.selected {
+button.visual-button.selected {
   border: 2px solid var(--color-input-border-selected)
 }
 button.filter-button {
   padding: 0.25rem .75rem;
 }
+
 
 .document {
   display: block;
@@ -351,6 +361,12 @@ a.document:hover {
 }
 ul.folder-list ul.folder-list {
     margin-left: 1.4em;
+}
+.folder-list button.text-button {
+  color: unset;
+  font-size: unset;
+  line-height: inherit;
+  width: 100%;
 }
 .details .header {
   margin: 3ex 0;
@@ -450,6 +466,10 @@ ul.folder-list ul.folder-list {
 .facet-head {
   display: flex;
 }
+.facet-head.text-button {
+  color: unset;
+  display: flex;
+}
 .facet-name {
   padding-left: 0.6em;
   font-weight: bold;
@@ -462,8 +482,12 @@ ul.folder-list ul.folder-list {
   padding: 0;
   list-style: none;
 }
-.facet-line {
+.facet-line button.text-button {
+  color: unset;
+  font-size: unset;
   display: flex;
+  line-height: inherit;
+  width: 100%;
 }
 .facet-clickable:hover .facet-value-text, .facet-clickable:hover .facet-name {
   text-decoration: underline;

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -190,8 +190,19 @@ article {
 .fixed-facet-filter .separator {
   margin: 0 0.4em;
 }
-.submit-buttons {
-  text-align: right;
+.bottom-controls {
+  min-height: 36px;
+  position: relative;
+}
+.bottom-controls .sidebar-switch {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+.bottom-controls .submit-buttons {
+  position: absolute;
+  bottom: 0;
+  right: 0;
 }
 /*
 .input-group > * {
@@ -236,7 +247,7 @@ button.text-button {
 }
 
 .filters-bar {
-  margin: 1rem 0;
+  margin: 0.7rem 0;
 }
 .filters-bar .fts-aspect-buttons button.text-button {
   margin: 0 0.10rem;
@@ -422,6 +433,9 @@ ul.folder-list ul.folder-list {
   margin-left: 1em;
   font-size: 80%;
   color: var(--color-text-light);
+}
+.sidebar-switch {
+  font-size: 80%;
 }
 .spinner {
   width: 3em;

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -135,9 +135,13 @@ main {
   min-height: 0;
 }
 aside {
-  flex: 4;
+  flex: 4 1 0%;
+  transition: flex-grow 0.2s;
   overflow: auto;
   /* border-right: 1px solid grey; */
+}
+aside.hidden {
+  flex-grow: 0;
 }
 aside nav {
   background-color: var(--color-nav-background);

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -148,6 +148,10 @@ article {
   padding: 0.5em;
 }
 
+.stick-on-wrapping {
+  display: inline-block;
+}
+
 .search-bar {
   display: flex;
   align-items: center;

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -209,6 +209,9 @@ input.hide-clear[type=search]::-ms-reveal {
 .filters-bar {
   margin: 1rem 0;
 }
+.filters-bar .fts-aspect-buttons .text-button{
+  margin: 0 0.25rem;
+}
 .filter-form {
   display: inline-block;
 }

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -155,6 +155,7 @@ article {
 .search-bar {
   display: flex;
   align-items: center;
+  margin-top: 10px;
   margin-bottom: 10px;
 }
 .search-bar  .search-label {

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -463,6 +463,13 @@ ul.folder-list ul.folder-list {
 .facet-box {
   margin-top: 1ex;
 }
+.facet-box {
+  border: 2px solid var(--color-nav-background);
+  transition: border-color 2s cubic-bezier(0, 1.59, 0.76, 1.1);
+}
+.facet-box.highlight {
+  border: 2px solid var(--color-primary);
+}
 .facet-head {
   display: flex;
 }

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -178,6 +178,9 @@ article {
   background: none;
   border: none;
 }
+.fixed-facet-filter .aspect-name {
+  font-weight: bold;
+}
 .submit-buttons {
   text-align: right;
 }

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -77,6 +77,9 @@ a, .text-button {
   color: var(--color-primary-lighter);
   text-decoration: none;
 }
+.text-button.text-button-negligible {
+  color: var(--color-text-light);
+}
 a:hover, .text-button:hover {
   text-decoration: underline;
 }
@@ -163,9 +166,14 @@ article {
 }
 .search-bar .search-input {
   flex: 1;
-  font-size: 105%;
+  font-size: 100%;
   border: none;
 }
+/* When the :has() "parent-selector" is getting implemented by the browsers we can use something like this:
+.search-input:has(input:focus) {
+  border-color: var(--color-primary-lighter);
+}
+*/
 .search-bar .clear-input {
   background: none;
   border: none;

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -403,6 +403,7 @@ ul.folder-list ul.folder-list {
 }
 .folder-head .folder-name {
   padding-left: 0.6em;
+  text-align: left;
 }
 .folder-head:hover .folder-name {
   text-decoration: underline;

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -32,6 +32,7 @@
 
     --color-text: var(--color-nightrider);
     --color-text-light: var(--color-grey);
+    --color-text-lighter: var(--color-suvagrey);
     --color-primary: var(--color-lochmara);
     --color-primary-lighter: var(--color-royalblue);
     --color-spot-1: var(--color-citrus);
@@ -186,6 +187,9 @@ article {
 .fixed-facet-filter .aspect-name {
   font-weight: bold;
 }
+.fixed-facet-filter .separator {
+  margin: 0 0.4em;
+}
 .submit-buttons {
   text-align: right;
 }
@@ -225,8 +229,11 @@ input.hide-clear[type=search]::-ms-reveal {
 .filters-bar {
   margin: 1rem 0;
 }
-.filters-bar .fts-aspect-buttons .text-button{
-  margin: 0 0.25rem;
+.filters-bar .fts-aspect-buttons .text-button {
+  margin: 0 0.10rem;
+}
+.filters-bar .fts-aspect-buttons .separator {
+  color: var(--color-text-light);
 }
 .filter-form {
   display: inline-block;

--- a/frontend/src/assets/index.html
+++ b/frontend/src/assets/index.html
@@ -17,6 +17,13 @@
       function (userSelectedUILanguageTag) {
         localStorage.setItem("selectedUILanguage", userSelectedUILanguageTag);
       });
+      app.ports.scrollElementIntoView.subscribe(
+        function (elementId) {
+          let element = document.getElementById(elementId);
+          if (element) {
+            element.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "start" });
+          }
+        });
     window.addEventListener('storage', function (ev) {
       if (ev.key == "selectedUILanguage") {
         app.ports.jsConfigChange.send(

--- a/frontend/src/elm/Entities/Markup.elm
+++ b/frontend/src/elm/Entities/Markup.elm
@@ -260,12 +260,11 @@ regexSemicolonFollowedBy =
 renderWwwAddress : Markup -> Markup
 renderWwwAddress (Markup topNodes) =
     topNodes
-        |> Debug.log "renderWwwAddress"
         |> List.map
             (\node ->
                 case node of
                     Html.Parser.Text text ->
-                        case Regex.find regexWwwAddress text |> Debug.log "find" of
+                        case Regex.find regexWwwAddress text of
                             [ match ] ->
                                 case match.submatches of
                                     [ Just url, Just linktext ] ->

--- a/frontend/src/elm/Setup.elm
+++ b/frontend/src/elm/Setup.elm
@@ -189,6 +189,13 @@ adjust adjustment model =
             , Cmd.none
             )
 
+        AdjustmentToSetup.HideSidebar state ->
+            ( { model
+                | config = model.config |> Config.adjustHideSidebar state
+              }
+            , Cmd.none
+            )
+
 
 {-| Gather the needs from the App and signal them to the cache.
 -}

--- a/frontend/src/elm/Types/AdjustmentToSetup.elm
+++ b/frontend/src/elm/Types/AdjustmentToSetup.elm
@@ -15,3 +15,4 @@ like switching the UI language.
 type AdjustmentToSetup
     = UserSelectedUILanguage Language
     | HideThumbnails Bool
+    | HideSidebar Bool

--- a/frontend/src/elm/Types/Config.elm
+++ b/frontend/src/elm/Types/Config.elm
@@ -2,7 +2,7 @@ module Types.Config exposing
     ( Config
     , init
     , updateFromServerSetup
-    , adjustUILanguage, adjustHideThumbnails
+    , adjustUILanguage, adjustHideThumbnails, adjustHideSidebar
     , getMaskName
     )
 
@@ -13,7 +13,7 @@ Most values are defined in the server and fetched dynamically.
 @docs Config
 @docs init
 @docs updateFromServerSetup
-@docs adjustUILanguage, adjustHideThumbnails
+@docs adjustUILanguage, adjustHideThumbnails, adjustHideSidebar
 @docs getMaskName
 
 -}
@@ -44,6 +44,7 @@ type alias Config =
     , facetAspects : List FacetAspectConfig
     , masks : MasksConfig
     , hideThumbnails : Bool
+    , hideSidebar : Bool
     , frontPage : Maybe Translations
     }
 
@@ -64,6 +65,7 @@ init =
     , facetAspects = []
     , masks = MasksConfig.init
     , hideThumbnails = False
+    , hideSidebar = False
     , frontPage = Nothing
     }
 
@@ -88,6 +90,15 @@ adjustHideThumbnails : Bool -> Config -> Config
 adjustHideThumbnails newState config =
     { config
         | hideThumbnails = newState
+    }
+
+
+{-| Set the globally configured option to hide the sidebar
+-}
+adjustHideSidebar : Bool -> Config -> Config
+adjustHideSidebar newState config =
+    { config
+        | hideSidebar = newState
     }
 
 

--- a/frontend/src/elm/Types/FacetValue.elm
+++ b/frontend/src/elm/Types/FacetValue.elm
@@ -1,18 +1,24 @@
 module Types.FacetValue exposing
     ( FacetValue, FacetValues, FacetsValues
     , facetsValuesFromDict
+    , valueTextWithSubstitution
     )
 
 {-|
 
 @docs FacetValue, FacetValues, FacetsValues
 @docs facetsValuesFromDict
+@docs valueTextWithSubstitution
 
 -}
 
 import Dict exposing (Dict)
+import Html exposing (Html)
 import Sort.Dict
+import String.Extra
 import Types.Aspect as Aspect exposing (Aspect)
+import Types.Config exposing (Config)
+import Types.Localization as Localization
 import Utils
 
 
@@ -46,3 +52,17 @@ facetsValuesFromDict dict =
         |> Dict.toList
         |> List.map (Tuple.mapFirst Aspect.fromString)
         |> Sort.Dict.fromList (Utils.sorter Aspect.ordering)
+
+
+valueTextWithSubstitution : Config -> String -> Html msg
+valueTextWithSubstitution config string =
+    if String.Extra.isBlank string then
+        Html.i []
+            [ Localization.text config
+                { en = "[not specified]"
+                , de = "[nicht angegeben]"
+                }
+            ]
+
+    else
+        Html.text string

--- a/frontend/src/elm/Types/Presentation.elm
+++ b/frontend/src/elm/Types/Presentation.elm
@@ -1,6 +1,6 @@
 module Types.Presentation exposing
     ( Presentation(..)
-    , getFolderId
+    , getFolderId, getSelection
     , fromRoute
     )
 
@@ -24,7 +24,7 @@ for the given route under the current knowledge about the relevant node types.
 Each variant of the type corresponds to a sub-component of [`UI.Article`](UI-Article).
 
 @docs Presentation
-@docs getFolderId
+@docs getFolderId, getSelection
 @docs fromRoute
 
 -}
@@ -70,6 +70,26 @@ getFolderId cache presentation =
 
         IteratorPresentation selection limit documentIdFromSearch ->
             Just selection.scope
+
+
+{-| -}
+getSelection : Presentation -> Maybe Selection
+getSelection presentation =
+    case presentation of
+        GenericPresentation _ ->
+            Nothing
+
+        DocumentPresentation _ _ ->
+            Nothing
+
+        CollectionPresentation _ ->
+            Nothing
+
+        ListingPresentation selection _ ->
+            Just selection
+
+        IteratorPresentation selection _ _ ->
+            Just selection
 
 
 {-| -}

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -14,10 +14,9 @@ import Cache exposing (Cache)
 import Constants
 import Html exposing (Html)
 import Html.Attributes
-import Html.Events
 import Types.AdjustmentToSetup as AdjustmentToSetup exposing (AdjustmentToSetup)
 import Types.Config exposing (Config)
-import Types.Localization as Localization exposing (Language)
+import Types.Localization as Localization
 import Types.Navigation as Navigation exposing (Navigation)
 import Types.Needs
 import Types.Presentation exposing (Presentation(..))

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -210,6 +210,9 @@ update context msg model =
                         UI.Controls.NoReturn ->
                             ( model1, cmd1, NoReturn )
 
+                        UI.Controls.AdjustSetup adjustment ->
+                            ( model1, cmd1, AdjustSetup adjustment )
+
                         UI.Controls.FocusOnFacet aspect ->
                             let
                                 ( facetModel, facetCmd ) =
@@ -333,29 +336,33 @@ view context model =
                 |> Html.map ControlsMsg
             ]
         , Html.main_ []
-            [ Html.aside []
-                [ Html.map TreeMsg <|
-                    UI.Tree.view
-                        { config = context.config
-                        , cache = context.cache
-                        , presentation = context.presentation
-                        }
-                        model.tree
-                        (UI.Article.folderCountsForQuery
+            [ if context.config.hideSidebar then
+                Html.text ""
+
+              else
+                Html.aside []
+                    [ Html.map TreeMsg <|
+                        UI.Tree.view
                             { config = context.config
                             , cache = context.cache
-                            , route = context.route
                             , presentation = context.presentation
                             }
-                        )
-                , Html.map FacetsMsg <|
-                    UI.Facets.view
-                        { config = context.config
-                        , cache = context.cache
-                        , presentation = context.presentation
-                        }
-                        model.facets
-                ]
+                            model.tree
+                            (UI.Article.folderCountsForQuery
+                                { config = context.config
+                                , cache = context.cache
+                                , route = context.route
+                                , presentation = context.presentation
+                                }
+                            )
+                    , Html.map FacetsMsg <|
+                        UI.Facets.view
+                            { config = context.config
+                            , cache = context.cache
+                            , presentation = context.presentation
+                            }
+                            model.facets
+                    ]
             , Html.map ArticleMsg <|
                 UI.Article.view
                     { config = context.config

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -336,33 +336,30 @@ view context model =
                 |> Html.map ControlsMsg
             ]
         , Html.main_ []
-            [ if context.config.hideSidebar then
-                Html.text ""
-
-              else
-                Html.aside []
-                    [ Html.map TreeMsg <|
-                        UI.Tree.view
+            [ Html.aside
+                [ Html.Attributes.classList [ ( "hidden", context.config.hideSidebar ) ] ]
+                [ Html.map TreeMsg <|
+                    UI.Tree.view
+                        { config = context.config
+                        , cache = context.cache
+                        , presentation = context.presentation
+                        }
+                        model.tree
+                        (UI.Article.folderCountsForQuery
                             { config = context.config
                             , cache = context.cache
+                            , route = context.route
                             , presentation = context.presentation
                             }
-                            model.tree
-                            (UI.Article.folderCountsForQuery
-                                { config = context.config
-                                , cache = context.cache
-                                , route = context.route
-                                , presentation = context.presentation
-                                }
-                            )
-                    , Html.map FacetsMsg <|
-                        UI.Facets.view
-                            { config = context.config
-                            , cache = context.cache
-                            , presentation = context.presentation
-                            }
-                            model.facets
-                    ]
+                        )
+                , Html.map FacetsMsg <|
+                    UI.Facets.view
+                        { config = context.config
+                        , cache = context.cache
+                        , presentation = context.presentation
+                        }
+                        model.facets
+                ]
             , Html.map ArticleMsg <|
                 UI.Article.view
                     { config = context.config

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -34,7 +34,6 @@ import Types exposing (DocumentIdFromSearch)
 import Types.Config as Config exposing (Config)
 import Types.Config.MasksConfig as MasksConfig
 import Types.Localization as Localization
-import Types.Navigation as Navigation
 import Types.Route exposing (Route)
 import UI.Icons
 import UI.Widgets.Breadcrumbs

--- a/frontend/src/elm/UI/Article/Iterator.elm
+++ b/frontend/src/elm/UI/Article/Iterator.elm
@@ -244,11 +244,13 @@ viewNavigationButtons context linkage =
             Html.button
                 (if List.isEmpty listOfNavigations then
                     [ Html.Attributes.type_ "button"
+                    , Html.Attributes.class "visual-button"
                     , Html.Attributes.disabled True
                     ]
 
                  else
                     [ Html.Attributes.type_ "button"
+                    , Html.Attributes.class "visual-button"
                     , Html.Events.onClick (ReturnNavigation (Navigation.ListOfNavigations listOfNavigations))
                     ]
                 )

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -36,7 +36,7 @@ import RemoteData
 import Types.ApiData exposing (ApiData)
 import Types.Config as Config exposing (Config)
 import Types.Config.MasksConfig as MasksConfig
-import Types.Id as Id exposing (DocumentId)
+import Types.Id exposing (DocumentId)
 import Types.Localization as Localization
 import Types.Navigation as Navigation exposing (Navigation)
 import Types.Route exposing (Route)

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -370,6 +370,7 @@ viewFooter context pageSequence =
         viewButton label msg enabled =
             Html.button
                 [ Html.Attributes.type_ "button"
+                , Html.Attributes.class "visual-button"
                 , Html.Attributes.disabled (not enabled)
                 , Html.Events.onClick msg
                 ]

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -58,6 +58,7 @@ type alias Context =
 {-| -}
 type Return
     = NoReturn
+    | FocusOnFacet Aspect
     | Navigate Navigation
 
 
@@ -190,8 +191,7 @@ update context msg model =
         SelectFacetFilter aspect ->
             ( model
             , Cmd.none
-            , NoReturn
-              -- TODO
+            , FocusOnFacet aspect
             )
 
         RemoveFacetFilter aspect ->

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -452,8 +452,8 @@ viewFacetFilters context =
             [ Html.Attributes.class "filters-bar" ]
             (Html.span []
                 [ Localization.text context.config
-                    { en = "Selection: "
-                    , de = "Auswahl: "
+                    { en = "Selected: "
+                    , de = "Ausgewählt: "
                     }
                 ]
                 :: listOfHtml
@@ -480,8 +480,8 @@ viewFacetFilter config isLastElement ( aspect, value ) =
             , Html.Events.onClick (RemoveFacetFilter aspect)
             ]
             [ Localization.text config
-                { en = "(remove)"
-                , de = "(<< alle)"
+                { en = "(unselect)"
+                , de = "(abwählen)"
                 }
             ]
         , if isLastElement then

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -34,6 +34,7 @@ import Types.Aspect as Aspect exposing (Aspect)
 import Types.Config exposing (Config)
 import Types.Config.FacetAspectConfig as FacetAspect
 import Types.Config.FtsAspectConfig as FtsAspect
+import Types.FacetValue as FacetValue exposing (FacetValues)
 import Types.FilterList as FilterList
 import Types.Localization as Localization
 import Types.Navigation as Navigation exposing (Navigation)
@@ -532,7 +533,7 @@ viewFacetFilter config isLastElement ( aspect, value ) =
             ]
         , Html.span
             [ Html.Attributes.class "aspect-value" ]
-            [ Html.text value ]
+            [ FacetValue.valueTextWithSubstitution config value ]
         , Html.text " "
         , Html.button
             [ Html.Attributes.type_ "button"

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -333,8 +333,8 @@ getSearchFieldPlaceholder context =
 viewFtsFilters : Config -> Model -> Html Msg
 viewFtsFilters config model =
     Html.div [ Html.Attributes.class "filters-bar" ]
-        [ viewExistingFtsFilters config model.ftsFilterLines
-        , viewFtsAspectButtons config model.ftsFilterLines
+        [ viewFtsAspectButtons config model.ftsFilterLines
+        , viewExistingFtsFilters config model.ftsFilterLines
         ]
 
 

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -427,6 +427,8 @@ viewFtsAspectButtons config ftsFilterLines =
                         [ Localization.text config label ]
                 )
                 config.ftsAspects
+                |> List.intersperse
+                    (Html.span [ Html.Attributes.class "separator" ] [ Html.text " · " ])
             )
         ]
 
@@ -454,9 +456,7 @@ viewFacetFilters context =
                     , de = "Auswahl: "
                     }
                 ]
-                :: (listOfHtml
-                        |> List.intersperse (Html.text " ")
-                   )
+                :: listOfHtml
             )
 
 
@@ -484,10 +484,9 @@ viewFacetFilter config isLastElement ( aspect, value ) =
                 , de = "(<< alle)"
                 }
             ]
-        , Html.text <|
-            if isLastElement then
-                ""
+        , if isLastElement then
+            Html.text ""
 
-            else
-                ", "
+          else
+            Html.span [ Html.Attributes.class "separator" ] [ Html.text "·" ]
         ]

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -267,7 +267,7 @@ viewSearch context model =
                 []
             , Html.button
                 [ Html.Attributes.type_ "button"
-                , Html.Attributes.class "clear-input"
+                , Html.Attributes.class "visual-button clear-input"
                 , Html.Attributes.disabled (model.globalFtsText == "")
                 , Html.Events.onClick ClearGlobalFtsText
                 ]
@@ -281,6 +281,7 @@ viewSearchButtons config model =
     Html.div [ Html.Attributes.class "submit-buttons" ]
         [ Html.button
             [ Html.Attributes.type_ "submit"
+            , Html.Attributes.class "visual-button"
             , Html.Attributes.classList
                 [ ( "selected"
                   , model.sorting == ByRank
@@ -296,6 +297,7 @@ viewSearchButtons config model =
             ]
         , Html.button
             [ Html.Attributes.type_ "submit"
+            , Html.Attributes.class "visual-button"
             , Html.Attributes.classList
                 [ ( "selected"
                   , model.sorting == ByDate
@@ -388,6 +390,7 @@ viewFtsFilter config aspect searchText =
                 []
             , Html.button
                 [ Html.Attributes.type_ "button"
+                , Html.Attributes.class "visual-button"
 
                 -- , Html.Attributes.disabled beingEdited
                 , Html.Events.onClick (RemoveFtsFilter aspect)
@@ -419,8 +422,9 @@ viewFtsAspectButtons config ftsFilterLines =
                             ftsFilterLineIsAlreadyOpen =
                                 Utils.List.findByMapping Tuple.first aspect ftsFilterLines /= Nothing
                         in
-                        Html.span
-                            [ Html.Attributes.class "text-button"
+                        Html.button
+                            [ Html.Attributes.type_ "button"
+                            , Html.Attributes.class "text-button"
                             , Html.Attributes.classList
                                 [ ( "text-button-negligible"
                                   , ftsFilterLineIsAlreadyOpen
@@ -474,8 +478,9 @@ viewFacetFilterButtons context listOfFacetFilters =
                             facetFilterIsAlreadyActive =
                                 Utils.List.findByMapping Tuple.first aspect listOfFacetFilters /= Nothing
                         in
-                        Html.span
-                            [ Html.Attributes.class "text-button"
+                        Html.button
+                            [ Html.Attributes.type_ "button"
+                            , Html.Attributes.class "text-button"
                             , Html.Attributes.classList
                                 [ ( "text-button-negligible"
                                   , facetFilterIsAlreadyActive
@@ -529,8 +534,9 @@ viewFacetFilter config isLastElement ( aspect, value ) =
             [ Html.Attributes.class "aspect-value" ]
             [ Html.text value ]
         , Html.text " "
-        , Html.span
-            [ Html.Attributes.class "text-button"
+        , Html.button
+            [ Html.Attributes.type_ "button"
+            , Html.Attributes.class "text-button"
             , Html.Events.onClick (RemoveFacetFilter aspect)
             ]
             [ Localization.text config

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -434,10 +434,13 @@ viewFtsAspectButtons config ftsFilterLines =
 viewFacetFilters : Context -> Html Msg
 viewFacetFilters context =
     let
-        listOfHtml =
+        listOfFacetFilters =
             context.route.parameters.facetFilters
                 |> FilterList.toList
-                |> List.map (viewFacetFilter context.config)
+
+        listOfHtml =
+            listOfFacetFilters
+                |> Utils.List.mapAndMarkLast (viewFacetFilter context.config)
     in
     if List.isEmpty listOfHtml then
         Html.text ""
@@ -452,15 +455,15 @@ viewFacetFilters context =
                     }
                 ]
                 :: (listOfHtml
-                        |> List.intersperse (Html.text ", ")
+                        |> List.intersperse (Html.text " ")
                    )
             )
 
 
-viewFacetFilter : Config -> Selection.FacetFilter -> Html Msg
-viewFacetFilter config ( aspect, value ) =
+viewFacetFilter : Config -> Bool -> Selection.FacetFilter -> Html Msg
+viewFacetFilter config isLastElement ( aspect, value ) =
     Html.span
-        [ Html.Attributes.class "fixed-facet-filter"
+        [ Html.Attributes.class "fixed-facet-filter stick-on-wrapping"
         ]
         [ Html.span
             [ Html.Attributes.class "aspect-name" ]
@@ -468,15 +471,23 @@ viewFacetFilter config ( aspect, value ) =
                 (FacetAspect.getLabelOrAspectName config aspect config.facetAspects)
             , Html.text ": "
             ]
-        , Html.text value
+        , Html.span
+            [ Html.Attributes.class "aspect-value" ]
+            [ Html.text value ]
         , Html.text " "
         , Html.span
             [ Html.Attributes.class "text-button"
             , Html.Events.onClick (RemoveFacetFilter aspect)
             ]
             [ Localization.text config
-                { en = " (remove)"
-                , de = " (<< alle)"
+                { en = "(remove)"
+                , de = "(<< alle)"
                 }
             ]
+        , Html.text <|
+            if isLastElement then
+                ""
+
+            else
+                ", "
         ]

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -34,7 +34,7 @@ import Types.Aspect as Aspect exposing (Aspect)
 import Types.Config exposing (Config)
 import Types.Config.FacetAspectConfig as FacetAspect
 import Types.Config.FtsAspectConfig as FtsAspect
-import Types.FacetValue as FacetValue exposing (FacetValues)
+import Types.FacetValue as FacetValue
 import Types.FilterList as FilterList
 import Types.Localization as Localization
 import Types.Navigation as Navigation exposing (Navigation)

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -433,36 +433,50 @@ viewFtsAspectButtons config ftsFilterLines =
 
 viewFacetFilters : Context -> Html Msg
 viewFacetFilters context =
-    Html.div [ Html.Attributes.class "filters-bar" ]
-        (context.route.parameters.facetFilters
-            |> FilterList.toList
-            |> List.map (viewFacetFilter context.config)
-        )
+    let
+        listOfHtml =
+            context.route.parameters.facetFilters
+                |> FilterList.toList
+                |> List.map (viewFacetFilter context.config)
+    in
+    if List.isEmpty listOfHtml then
+        Html.text ""
+
+    else
+        Html.div
+            [ Html.Attributes.class "filters-bar" ]
+            (Html.span []
+                [ Localization.text context.config
+                    { en = "Selected properties: "
+                    , de = "Ausgewählte Eigenschaften: "
+                    }
+                ]
+                :: (listOfHtml
+                        |> List.intersperse (Html.text ", ")
+                   )
+            )
 
 
 viewFacetFilter : Config -> Selection.FacetFilter -> Html Msg
 viewFacetFilter config ( aspect, value ) =
-    Html.div
-        [ Html.Attributes.class "search-bar"
+    Html.span
+        [ Html.Attributes.class "fixed-facet-filter"
         ]
-        [ Html.label
-            [ Html.Attributes.class "search-label" ]
+        [ Html.span
+            [ Html.Attributes.class "aspect-name" ]
             [ Html.text
                 (FacetAspect.getLabelOrAspectName config aspect config.facetAspects)
+            , Html.text ": "
             ]
+        , Html.text value
+        , Html.text " "
         , Html.span
-            [ Html.Attributes.class "input-group" ]
-            [ Html.div
-                [ Html.Attributes.class "search-input"
-                ]
-                [ Html.text value ]
-            , Html.button
-                [ Html.Attributes.type_ "button"
-
-                -- , Html.Attributes.disabled beingEdited
-                , Html.Events.onClick (RemoveFacetFilter aspect)
-                , Html.Attributes.class "filter-button"
-                ]
-                [ UI.Icons.clear ]
+            [ Html.Attributes.class "text-button"
+            , Html.Events.onClick (RemoveFacetFilter aspect)
+            ]
+            [ Localization.text config
+                { en = " (remove)"
+                , de = " (<< alle)"
+                }
             ]
         ]

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -30,6 +30,7 @@ import Maybe.Extra
 import RemoteData
 import String.Format
 import Task
+import Types.AdjustmentToSetup as AdjustmentToSetup exposing (AdjustmentToSetup)
 import Types.Aspect as Aspect exposing (Aspect)
 import Types.Config exposing (Config)
 import Types.Config.FacetAspectConfig as FacetAspect
@@ -59,6 +60,7 @@ type alias Context =
 {-| -}
 type Return
     = NoReturn
+    | AdjustSetup AdjustmentToSetup
     | FocusOnFacet Aspect
     | Navigate Navigation
 
@@ -74,6 +76,7 @@ type alias Model =
 {-| -}
 type Msg
     = NoOp
+    | ReturnAdjustmentToSetup AdjustmentToSetup
     | SetGlobalFtsText String
     | ClearGlobalFtsText
     | AddFtsFilter Aspect
@@ -126,6 +129,12 @@ update context msg model =
             ( model
             , Cmd.none
             , NoReturn
+            )
+
+        ReturnAdjustmentToSetup adjustment ->
+            ( model
+            , Cmd.none
+            , AdjustSetup adjustment
             )
 
         SetGlobalFtsText globalFtsText ->
@@ -241,7 +250,7 @@ view context model =
             [ viewSearch context model
             , viewFtsFilters context.config model
             , viewFacetFilters context
-            , viewSearchButtons context.config model
+            , viewBottomControls context.config model
             ]
         ]
 
@@ -273,6 +282,39 @@ viewSearch context model =
                 , Html.Events.onClick ClearGlobalFtsText
                 ]
                 [ UI.Icons.clear ]
+            ]
+        ]
+
+
+viewBottomControls : Config -> Model -> Html Msg
+viewBottomControls config model =
+    Html.div
+        [ Html.Attributes.class "bottom-controls" ]
+        [ viewSearchButtons config model
+        , viewSidebarButton config model
+        ]
+
+
+viewSidebarButton : Config -> Model -> Html Msg
+viewSidebarButton config model =
+    Html.div
+        [ Html.Attributes.class "sidebar-switch" ]
+        [ Html.button
+            [ Html.Attributes.type_ "button"
+            , Html.Attributes.class "text-button"
+            , Html.Events.onClick <|
+                ReturnAdjustmentToSetup (AdjustmentToSetup.HideSidebar (not config.hideSidebar))
+            ]
+            [ Localization.text config <|
+                if config.hideSidebar then
+                    { en = "Show Sidebar"
+                    , de = "Seitenleiste einblenden"
+                    }
+
+                else
+                    { en = "Hide Sidebar"
+                    , de = "Seitenleiste ausblenden"
+                    }
             ]
         ]
 

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -457,7 +457,7 @@ viewFacetFilters context =
                 listOfFacetFilters =
                     selection.facetFilters |> FilterList.toList
             in
-            Html.div [ Html.Attributes.class "filters-bar" ]
+            Html.div [ Html.Attributes.class "filters-bar facet-controls" ]
                 [ viewFacetFilterButtons context listOfFacetFilters
                 , viewSelectedFacetFilters context listOfFacetFilters
                 ]

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -450,8 +450,8 @@ viewFacetFilters context =
             [ Html.Attributes.class "filters-bar" ]
             (Html.span []
                 [ Localization.text context.config
-                    { en = "Selected properties: "
-                    , de = "Ausgewählte Eigenschaften: "
+                    { en = "Selection: "
+                    , de = "Auswahl: "
                     }
                 ]
                 :: (listOfHtml
@@ -469,7 +469,7 @@ viewFacetFilter config isLastElement ( aspect, value ) =
             [ Html.Attributes.class "aspect-name" ]
             [ Html.text
                 (FacetAspect.getLabelOrAspectName config aspect config.facetAspects)
-            , Html.text ": "
+            , Html.text " "
             ]
         , Html.span
             [ Html.Attributes.class "aspect-value" ]

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -373,25 +373,29 @@ viewFtsFilter config aspect searchText =
 
 viewFtsAspectButtons : Config -> List ( Aspect, String ) -> Html Msg
 viewFtsAspectButtons config ftsFilterLines =
-    Html.div [] <|
-        List.filterMap
-            (\{ aspect, label } ->
-                if Utils.List.findByMapping Tuple.first aspect ftsFilterLines == Nothing then
-                    Just <|
-                        Html.span
-                            [ Html.Attributes.class "" ]
-                            [ Html.button
-                                [ Html.Attributes.type_ "button"
-                                , Html.Attributes.class "add-filter-button"
+    Html.div []
+        [ Localization.text config
+            { en = "Search for: "
+            , de = "Suchen nach: "
+            }
+        , Html.span
+            [ Html.Attributes.class "fts-aspect-buttons" ]
+            (List.filterMap
+                (\{ aspect, label } ->
+                    if Utils.List.findByMapping Tuple.first aspect ftsFilterLines == Nothing then
+                        Just <|
+                            Html.span
+                                [ Html.Attributes.class "text-button"
                                 , Html.Events.onClick <| AddFtsFilter aspect
                                 ]
                                 [ Localization.text config label ]
-                            ]
 
-                else
-                    Nothing
+                    else
+                        Nothing
+                )
+                config.ftsAspects
             )
-            config.ftsAspects
+        ]
 
 
 viewFacetFilters : Context -> Html Msg

--- a/frontend/src/elm/UI/Facets.elm
+++ b/frontend/src/elm/UI/Facets.elm
@@ -4,7 +4,7 @@ module UI.Facets exposing
     , Model
     , Msg
     , initialModel
-    , update
+    , update, focusOnFacet
     , view
     )
 
@@ -15,7 +15,7 @@ module UI.Facets exposing
 @docs Model
 @docs Msg
 @docs initialModel
-@docs update
+@docs update, focusOnFacet
 @docs view
 
 -}
@@ -111,6 +111,20 @@ update context msg model =
             , Cmd.none
             , NoReturn
             )
+
+
+{-| -}
+focusOnFacet : Context -> Aspect -> Model -> ( Model, Cmd Msg )
+focusOnFacet context aspect model =
+    let
+        _ =
+            Debug.log "focusOnFacet" aspect
+    in
+    ( { model
+        | showCollapsed = Sort.Dict.insert aspect False model.showCollapsed
+      }
+    , Cmd.none
+    )
 
 
 {-| -}

--- a/frontend/src/elm/UI/Facets.elm
+++ b/frontend/src/elm/UI/Facets.elm
@@ -150,10 +150,6 @@ update context msg model =
 {-| -}
 focusOnFacet : Context -> Aspect -> Model -> ( Model, Cmd Msg )
 focusOnFacet context aspect model =
-    let
-        _ =
-            Debug.log "focusOnFacet" aspect
-    in
     ( { model
         | showCollapsed = Sort.Dict.insert aspect False model.showCollapsed
       }

--- a/frontend/src/elm/UI/Facets.elm
+++ b/frontend/src/elm/UI/Facets.elm
@@ -32,7 +32,7 @@ import Task
 import Types.Aspect as Aspect exposing (Aspect)
 import Types.Config exposing (Config)
 import Types.Config.FacetAspectConfig as FacetAspect exposing (FacetAspectConfig)
-import Types.FacetValue exposing (FacetValues)
+import Types.FacetValue as FacetValue exposing (FacetValues)
 import Types.FilterList as FilterList
 import Types.Localization as Localization
 import Types.Navigation as Navigation exposing (Navigation)
@@ -292,12 +292,7 @@ viewFacetSelection config aspect selectedValue maybeCount =
             ]
             [ Html.span
                 [ Html.Attributes.class "facet-value-text" ]
-                [ if String.isEmpty selectedValue then
-                    viewNotSpecified config
-
-                  else
-                    Html.text selectedValue
-                ]
+                [ FacetValue.valueTextWithSubstitution config selectedValue ]
             , case maybeCount of
                 Just count ->
                     Html.span
@@ -338,12 +333,7 @@ viewFacetValues config model aspect facetValues =
                             ]
                             [ Html.span
                                 [ Html.Attributes.class "facet-value-text" ]
-                                [ if String.isEmpty value then
-                                    viewNotSpecified config
-
-                                  else
-                                    Html.text value
-                                ]
+                                [ FacetValue.valueTextWithSubstitution config value ]
                             , Html.span
                                 [ Html.Attributes.class "facet-value-count" ]
                                 [ Html.text <| "(" ++ String.fromInt count ++ ")" ]
@@ -380,13 +370,3 @@ viewFacetValues config model aspect facetValues =
                 ]
             ]
     ]
-
-
-viewNotSpecified : Config -> Html msg
-viewNotSpecified config =
-    Html.i []
-        [ Localization.text config
-            { en = "[not specified]"
-            , de = "[nicht angegeben]"
-            }
-        ]

--- a/frontend/src/elm/UI/Facets.elm
+++ b/frontend/src/elm/UI/Facets.elm
@@ -176,8 +176,9 @@ viewFacet context model selection facetAspectConfig =
         [ Html.Attributes.id (idOfFacetBox facetAspectConfig.aspect)
         , Html.Attributes.class "facet-box"
         ]
-        [ Html.div
-            [ Html.Attributes.class "facet-head facet-clickable"
+        [ Html.button
+            [ Html.Attributes.type_ "button"
+            , Html.Attributes.class "text-button facet-head facet-clickable"
             , Html.Events.onClick (ShowFacetCollapsed facetAspectConfig.aspect (not showCollapsed))
             , Html.Attributes.classList
                 [ ( "expanded", not showCollapsed ) ]
@@ -301,17 +302,22 @@ viewFacetValues config model aspect facetValues =
                         [ Html.Attributes.class "facet-line facet-clickable"
                         , Html.Events.onClick (SelectFacetValue aspect value)
                         ]
-                        [ Html.span
-                            [ Html.Attributes.class "facet-value-text" ]
-                            [ if String.isEmpty value then
-                                viewNotSpecified config
-
-                              else
-                                Html.text value
+                        [ Html.button
+                            [ Html.Attributes.type_ "button"
+                            , Html.Attributes.class "text-button"
                             ]
-                        , Html.span
-                            [ Html.Attributes.class "facet-value-count" ]
-                            [ Html.text <| "(" ++ String.fromInt count ++ ")" ]
+                            [ Html.span
+                                [ Html.Attributes.class "facet-value-text" ]
+                                [ if String.isEmpty value then
+                                    viewNotSpecified config
+
+                                  else
+                                    Html.text value
+                                ]
+                            , Html.span
+                                [ Html.Attributes.class "facet-value-count" ]
+                                [ Html.text <| "(" ++ String.fromInt count ++ ")" ]
+                            ]
                         ]
             )
             facetValues
@@ -323,19 +329,24 @@ viewFacetValues config model aspect facetValues =
             [ Html.Attributes.class "facet-line facet-clickable facet-special-action"
             , Html.Events.onClick (ShowFacetLongList aspect showShortList)
             ]
-            [ Html.span
-                [ Html.Attributes.class "facet-value-text" ]
-                [ if showShortList then
-                    Localization.text config
-                        { en = ">> More"
-                        , de = ">> mehr"
-                        }
+            [ Html.button
+                [ Html.Attributes.type_ "button"
+                , Html.Attributes.class "text-button"
+                ]
+                [ Html.span
+                    [ Html.Attributes.class "facet-value-text" ]
+                    [ if showShortList then
+                        Localization.text config
+                            { en = ">> More"
+                            , de = ">> mehr"
+                            }
 
-                  else
-                    Localization.text config
-                        { en = "<< Less"
-                        , de = "<< weniger"
-                        }
+                      else
+                        Localization.text config
+                            { en = "<< Less"
+                            , de = "<< weniger"
+                            }
+                    ]
                 ]
             ]
     ]

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -27,7 +27,7 @@ module UI.Tree exposing
 
 import Cache exposing (Cache)
 import Cache.Derive
-import Entities.Folder as Folder exposing (Folder)
+import Entities.Folder exposing (Folder)
 import Entities.FolderCounts exposing (FolderCounts)
 import Html exposing (Html)
 import Html.Attributes

--- a/frontend/src/elm/UI/Tree.elm
+++ b/frontend/src/elm/UI/Tree.elm
@@ -215,8 +215,11 @@ viewFolderTree context model isToplevel maybeFolderCounts id =
                     isSelectedFolder =
                         presentationFolderId == Just id
                 in
-                [ Html.div
-                    [ Html.Events.onClick (Select id) ]
+                [ Html.button
+                    [ Html.Attributes.type_ "button"
+                    , Html.Attributes.class "text-button"
+                    , Html.Events.onClick (Select id)
+                    ]
                     [ viewFolderLine
                         folder
                         isToplevel

--- a/frontend/src/elm/UI/Widgets/ThumbnailSwitch.elm
+++ b/frontend/src/elm/UI/Widgets/ThumbnailSwitch.elm
@@ -16,8 +16,9 @@ import Types.Localization as Localization
 {-| -}
 view : Config -> Bool -> (Bool -> msg) -> Html msg
 view config state msgFromState =
-    Html.span
-        [ Html.Events.onClick (msgFromState (not state))
+    Html.button
+        [ Html.Attributes.type_ "button"
+        , Html.Events.onClick (msgFromState (not state))
         , Html.Attributes.class "text-button"
         ]
         [ Localization.text config <|

--- a/frontend/src/elm/Utils/List.elm
+++ b/frontend/src/elm/Utils/List.elm
@@ -5,6 +5,7 @@ module Utils.List exposing
     , findByMapping, filterByMapping, filterByNotMapping, replaceOnMapping, setOnMapping, updateOnMapping
     , mapWhile, mapEllipsis
     , lexicalOrdering
+    , mapAndMarkLast
     )
 
 {-|
@@ -15,6 +16,7 @@ module Utils.List exposing
 @docs findByMapping, filterByMapping, filterByNotMapping, replaceOnMapping, setOnMapping, updateOnMapping
 @docs mapWhile, mapEllipsis
 @docs lexicalOrdering
+@docs mapAndMarkLast
 
 -}
 
@@ -276,3 +278,14 @@ lexicalOrdering compareElements listL listR =
 
                 EQ ->
                     lexicalOrdering compareElements tailL tailR
+
+
+mapAndMarkLast : (Bool -> a -> b) -> List a -> List b
+mapAndMarkLast f xs =
+    List.foldr
+        (\x ( mark, acc ) ->
+            ( False, f mark x :: acc )
+        )
+        ( True, [] )
+        xs
+        |> Tuple.second

--- a/frontend/tests/Tests/Utils/List.elm
+++ b/frontend/tests/Tests/Utils/List.elm
@@ -287,6 +287,32 @@ suite =
                 (Fuzz.list Fuzz.int)
                 (Utils.List.lexicalOrdering compare)
             ]
+        , let
+            f isLast x =
+                if isLast then
+                    x * 4
+
+                else
+                    x * 2
+          in
+          describe "mapAndMarkLast"
+            [ test "on empty list" <|
+                \() ->
+                    Utils.List.mapAndMarkLast f []
+                        |> Expect.equal []
+            , test "one element" <|
+                \() ->
+                    Utils.List.mapAndMarkLast f [ 10 ]
+                        |> Expect.equal [ 40 ]
+            , test "two elements" <|
+                \() ->
+                    Utils.List.mapAndMarkLast f [ 10, 11 ]
+                        |> Expect.equal [ 20, 44 ]
+            , test "four elements" <|
+                \() ->
+                    Utils.List.mapAndMarkLast f [ 10, 11, 12, 13 ]
+                        |> Expect.equal [ 20, 22, 24, 52 ]
+            ]
         ]
 
 


### PR DESCRIPTION
- Search aspect buttons:
    - Use smaller text-like buttons
    - Always show each button
    - Set focus to search input in button click
    - Move buttons above search inputs

- Facet filters
    - More compact, text-like layout
    - Wording
    - Add buttons to jump to facet boxes
    - Scroll facet-box into view and highlight it when selected by button click
    - Set aside enough space for one line of selected facets

- General UI
    - All text-like buttons a rendered as HTML-buttons for accessibility
    - Add button to hide the sidebar
    - Animate hiding sidebar
