### PR TITLE
Document link into mediatum

### DIFF
--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -2,7 +2,7 @@ module Constants exposing
     ( apiUrl, graphqlOperationNamePrefix
     , incrementLimitOnLoadMore
     , maxAttributeLengthInListingView
-    , contentServerUrls
+    , externalServerUrls
     )
 
 {-| Configurable values
@@ -61,15 +61,17 @@ maxAttributeLengthInListingView =
 This value is a record of URL building functions to this server.
 
 -}
-contentServerUrls :
+externalServerUrls :
     { thumbnail : Id.DocumentId -> String
     , presentation : Id.DocumentId -> String
+    , item : String -> String
     }
-contentServerUrls =
+externalServerUrls =
     let
         appendId base id =
             base ++ Id.toString id
     in
     { thumbnail = "https://mediatum.ub.tum.de/thumbs/" |> appendId
     , presentation = "https://mediatum.ub.tum.de/thumb2/" |> appendId
+    , item = \itemSpec -> "https://mediatum.ub.tum.de/?item=" ++ itemSpec ++ ".html"
     }

--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -65,6 +65,7 @@ externalServerUrls :
     { thumbnail : Id.DocumentId -> String
     , presentation : Id.DocumentId -> String
     , item : String -> String
+    , documentPermanent : Id.DocumentId -> String
     }
 externalServerUrls =
     let
@@ -74,4 +75,5 @@ externalServerUrls =
     { thumbnail = "https://mediatum.ub.tum.de/thumbs/" |> appendId
     , presentation = "https://mediatum.ub.tum.de/thumb2/" |> appendId
     , item = \itemSpec -> "https://mediatum.ub.tum.de/?item=" ++ itemSpec ++ ".html"
+    , documentPermanent = "https://mediatum.ub.tum.de/" |> appendId
     }

--- a/frontend/src/elm/Types/Navigation.elm
+++ b/frontend/src/elm/Types/Navigation.elm
@@ -29,7 +29,7 @@ import Types.Selection exposing (FtsFilters, GlobalFts, Sorting)
 type Navigation
     = ListOfNavigations (List Navigation)
     | ShowDocument FolderId DocumentId
-    | ShowDocumentPermalink DocumentId
+    | ShowDocumentWithoutContext DocumentId
     | ShowListingWithoutDocument
     | ShowListingWithFolder FolderId
     | ShowListingWithSearchAndFtsFilter GlobalFts FtsFilters Sorting
@@ -84,7 +84,7 @@ alterRoute config cache navigation route =
                         (documentId |> Id.asNodeId)
             }
 
-        ShowDocumentPermalink documentId ->
+        ShowDocumentWithoutContext documentId ->
             Route.initDocumentWithoutFolder config documentId
 
         ShowListingWithoutDocument ->

--- a/frontend/src/elm/UI.elm
+++ b/frontend/src/elm/UI.elm
@@ -11,6 +11,7 @@ module UI exposing
 -}
 
 import Cache exposing (Cache)
+import Constants
 import Html exposing (Html)
 import Html.Attributes
 import Html.Events
@@ -337,25 +338,25 @@ view context model =
             ]
         , Html.footer [] <|
             let
-                item href en de =
+                item itemSpec en de =
                     Html.a
-                        [ Html.Attributes.href href ]
+                        [ Html.Attributes.href (Constants.externalServerUrls.item itemSpec) ]
                         [ Localization.text context.config { en = en, de = de } ]
             in
             -- TODO: Fix the links. We currently cannot show ids like "604993_12"
             [ Html.span
                 [ Html.Attributes.class "footer-right" ]
-                [ item "https://mediatum.ub.tum.de/?item=604993_13.html" "Impressum" "Impressum"
-                , item "https://mediatum.ub.tum.de/?item=604993_18.html" "Barrierefreiheit" "Barrierefreiheit"
-                , item "https://mediatum.ub.tum.de/?item=604993_9.html" "Privacy" "Datenschutz"
-                , item "https://mediatum.ub.tum.de/?item=604993_12.html" "Nutzungsrechte" "Nutzungsrechte"
+                [ item "604993_13" "Impressum" "Impressum"
+                , item "604993_18" "Barrierefreiheit" "Barrierefreiheit"
+                , item "604993_9" "Privacy" "Datenschutz"
+                , item "604993_12" "Nutzungsrechte" "Nutzungsrechte"
                 ]
             , Html.span
                 [ Html.Attributes.class "footer-left" ]
                 [ item "mailto:mediatum@ub.tum.de" "mediatum@ub.tum.de" "mediatum@ub.tum.de"
-                , item "https://mediatum.ub.tum.de/?item=604993_15.html" "Contact" "Kontakt"
-                , item "https://mediatum.ub.tum.de/?item=604993_17.html" "About mediaTUM" "Über mediaTUM"
-                , item "https://mediatum.ub.tum.de/?item=604993_14.html" "Help" "Hilfe"
+                , item "604993_15" "Contact" "Kontakt"
+                , item "604993_17" "About mediaTUM" "Über mediaTUM"
+                , item "604993_14" "Help" "Hilfe"
                 ]
             ]
         ]

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -110,9 +110,8 @@ viewDocument context model document residence =
     Html.div []
         [ Html.div [ Html.Attributes.class "permalink" ]
             [ Html.a
-                [ Navigation.alterRouteHref
-                    context
-                    (Navigation.ShowDocumentPermalink document.id)
+                [ Html.Attributes.href
+                    (Constants.externalServerUrls.documentPermanent document.id)
                 ]
                 [ Localization.text context.config
                     { en = "Permanent link"

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -128,7 +128,7 @@ viewDocument context model document residence =
                 [ Html.Attributes.class "thumbnail" ]
                 [ Html.img
                     [ Html.Attributes.src
-                        (Constants.contentServerUrls.presentation document.id)
+                        (Constants.externalServerUrls.presentation document.id)
                     ]
                     []
                 ]

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -112,10 +112,15 @@ viewDocument context model document residence =
             [ Html.a
                 [ Html.Attributes.href
                     (Constants.externalServerUrls.documentPermanent document.id)
+                , Html.Attributes.title <|
+                    Localization.string context.config
+                        { en = "Persistent link to the document in mediaTUM"
+                        , de = "Dauerhafter Verweis auf das Dokument in mediaTUM"
+                        }
                 ]
                 [ Localization.text context.config
-                    { en = "Permanent link"
-                    , de = "Dauerhafter Link"
+                    { en = "Show this document in mediaTUM"
+                    , de = "Zeige dieses Dokument in mediaTUM"
                     }
                 ]
             ]

--- a/frontend/src/elm/UI/Article/Listing.elm
+++ b/frontend/src/elm/UI/Article/Listing.elm
@@ -204,7 +204,7 @@ viewDocument context number document =
                 [ Html.Attributes.class "thumbnail" ]
                 [ Html.img
                     [ Html.Attributes.src
-                        (Constants.contentServerUrls.thumbnail document.id)
+                        (Constants.externalServerUrls.thumbnail document.id)
                     ]
                     []
                 ]


### PR DESCRIPTION
- Show a (persisting, i.e. permanent) link to the document within the existing mediaTUM installation
- Wording: "Show this document in mediaTUM", with tool-tip "Persistent link to the document in mediaTUM"

We don't include the folder identity when constructing the link. Reasons:
- If the folder is a collection (as opposed to a directory), mediaTUM will show the collection's front page, not the document.
- mediaTUM will navigate to an appropriate directory anyway, most likely within the collection "University Bibliography".