### PR TITLE
Handle files

### DIFF
--- a/backend/src/sql/api/api-document.sql
+++ b/backend/src/sql/api/api-document.sql
@@ -255,3 +255,18 @@ $$ language sql strict stable parallel safe;
 comment on function api.document_values_by_mask (document api.document, mask_name text, highlight_search_term text) is
     'Gets the meta field values of this document as a JSON value, selected by a named mask. '
     'Optionally mark the occurences of a search term given as highlightSearchTerm.';
+
+
+create or replace function api.document_files
+    ( document api.document
+    )
+    returns api.file[] as $$
+    select array(
+        select row(file.filetype, file.mimetype)::api.file
+        from entity.file
+        where document.id = file.document_id
+    )
+$$ language sql stable;
+
+comment on function api.document_files (document api.document) is
+    'Gets the list of files (if permitted) associated with the document.';

--- a/backend/src/sql/api/auxiliary.sql
+++ b/backend/src/sql/api/auxiliary.sql
@@ -301,6 +301,16 @@ create or replace function aux.is_public_today (nodeId int4)
 $$ language sql stable;
 
 
+create or replace function aux.data_is_public_today (nodeId int4)
+    returns boolean as $$
+    select mediatum.has_data_access_to_node (nodeId,
+            _group_ids => '{2}', -- Group ID 2 is 'Gast' here. May need a more generic lookup.
+            ipaddr => inet '0.0.0.0',
+            _date => date 'today'
+        )
+$$ language sql stable;
+
+
 create or replace function aux.nodetype_is_container (nodetype1 varchar)
     returns boolean as $$
     select exists

--- a/backend/src/sql/api/entities.sql
+++ b/backend/src/sql/api/entities.sql
@@ -195,7 +195,9 @@ create or replace view entity.file as
     from entity.document, mediatum.node_to_file, mediatum.file
     where document.id = node_to_file.nid
       and node_to_file.file_id = file.id
-      and aux.data_is_public_today (document.id);
+      and (file.filetype in ('thumb', 'presentation')
+           or aux.data_is_public_today (document.id)
+          );
 
 
 -- View on node for getting documents, where we don't need to check `not nodetype.is_container`

--- a/backend/src/sql/api/entities.sql
+++ b/backend/src/sql/api/entities.sql
@@ -186,6 +186,18 @@ create or replace view entity.document as
       and aux.is_public_today (node.id);
 
 
+create or replace view entity.file as
+    select
+        document.id as document_id,
+        file.id,
+        file.filetype,
+        file.mimetype
+    from entity.document, mediatum.node_to_file, mediatum.file
+    where document.id = node_to_file.nid
+      and node_to_file.file_id = file.id
+      and aux.data_is_public_today (document.id);
+
+
 -- View on node for getting documents, where we don't need to check `not nodetype.is_container`
 create or replace view entity.node as
     select

--- a/backend/src/sql/api/types.sql
+++ b/backend/src/sql/api/types.sql
@@ -283,6 +283,19 @@ comment on column api.document_from_search.tsquery is
     '@omit';
 
 
+create type api.file as
+    ( filetype text
+    , mimetype text
+    );
+
+comment on type api.file is
+    'Data about a file associated with a document';
+comment on column api.file.filetype is
+    'Common filetype are "document", "thumb", "presentation"';
+comment on column api.file.mimetype is
+    'The mimetype of the file';
+
+
 create type api.fts_sorting as enum
     ( 'by_rank'
     , 'by_date'

--- a/frontend/src/elm/Api/Queries.elm
+++ b/frontend/src/elm/Api/Queries.elm
@@ -231,7 +231,7 @@ genericNode maskName nodeId =
                 (Mediatum.Object.GenericNode.asDocument
                     (SelectionSet.succeed Tuple.pair
                         |> SelectionSet.with
-                            (Api.Fragments.documentByMask maskName Nothing)
+                            (Api.Fragments.documentByMask maskName Nothing True)
                         |> SelectionSet.with
                             Api.Fragments.documentResidence
                     )
@@ -473,7 +473,7 @@ documentDetails maskName documentIdFromSearch withResidence =
         { id = Id.toInt documentIdFromSearch.id }
         (SelectionSet.succeed Tuple.pair
             |> SelectionSet.with
-                (Api.Fragments.documentByMask maskName documentIdFromSearch.search)
+                (Api.Fragments.documentByMask maskName documentIdFromSearch.search True)
             |> (if withResidence then
                     SelectionSet.with
                         (Api.Fragments.documentResidence

--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -68,6 +68,8 @@ externalServerUrls :
     , presentation : Id.DocumentId -> String
     , item : String -> String
     , documentPermanent : Id.DocumentId -> String
+    , showDocumentPdf : Id.DocumentId -> String
+    , downloadDocumentPdf : Id.DocumentId -> String
     }
 externalServerUrls =
     let
@@ -78,6 +80,12 @@ externalServerUrls =
     , presentation = "https://mediatum.ub.tum.de/thumb2/" |> appendId
     , item = \itemSpec -> "https://mediatum.ub.tum.de/?item=" ++ itemSpec ++ ".html"
     , documentPermanent = "https://mediatum.ub.tum.de/" |> appendId
+    , showDocumentPdf =
+        \id ->
+            "https://mediatum.ub.tum.de/doc/" ++ Id.toString id ++ "/" ++ Id.toString id ++ ".pdf"
+    , downloadDocumentPdf =
+        \id ->
+            "https://mediatum.ub.tum.de/download/" ++ Id.toString id ++ "/" ++ Id.toString id ++ ".pdf"
     }
 
 
@@ -85,7 +93,9 @@ externalServerUrls =
 -}
 filetypes :
     { presentation : String
+    , document : String
     }
 filetypes =
     { presentation = "presentation"
+    , document = "document"
     }

--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -3,6 +3,7 @@ module Constants exposing
     , incrementLimitOnLoadMore
     , maxAttributeLengthInListingView
     , externalServerUrls
+    , filetypes
     )
 
 {-| Configurable values
@@ -10,7 +11,8 @@ module Constants exposing
 @docs apiUrl, graphqlOperationNamePrefix
 @docs incrementLimitOnLoadMore
 @docs maxAttributeLengthInListingView
-@docs contentServerUrls
+@docs externalServerUrls
+@docs filetypes
 
 -}
 
@@ -76,4 +78,14 @@ externalServerUrls =
     , presentation = "https://mediatum.ub.tum.de/thumb2/" |> appendId
     , item = \itemSpec -> "https://mediatum.ub.tum.de/?item=" ++ itemSpec ++ ".html"
     , documentPermanent = "https://mediatum.ub.tum.de/" |> appendId
+    }
+
+
+{-| Identifier used for certain relevant filetypes associated with documents
+-}
+filetypes :
+    { presentation : String
+    }
+filetypes =
+    { presentation = "presentation"
     }

--- a/frontend/src/elm/Entities/Document.elm
+++ b/frontend/src/elm/Entities/Document.elm
@@ -1,6 +1,7 @@
 module Entities.Document exposing
     ( Document, Attribute, SearchMatching
     , init, attributeValue
+    , File, Files
     )
 
 {-| The metadata of a document and its attributes.
@@ -29,6 +30,7 @@ type alias Document =
     , metadatatypeName : String
     , attributes : List Attribute
     , searchMatching : Maybe SearchMatching
+    , files : Maybe Files
     }
 
 
@@ -55,6 +57,20 @@ type alias SearchMatching =
     }
 
 
+{-| A list of associated files
+-}
+type alias Files =
+    List File
+
+
+{-| Specification of an associated file
+-}
+type alias File =
+    { filetype : String
+    , mimetype : String
+    }
+
+
 {-| -}
 init :
     DocumentId
@@ -62,13 +78,15 @@ init :
     -> String
     -> List Attribute
     -> Maybe SearchMatching
+    -> Maybe Files
     -> Document
-init id metadatatypeName name attributes searchMatching =
+init id metadatatypeName name attributes searchMatching files =
     { id = id
     , name = name
     , metadatatypeName = metadatatypeName
     , attributes = attributes
     , searchMatching = searchMatching
+    , files = files
     }
 
 

--- a/frontend/src/elm/Entities/Document.elm
+++ b/frontend/src/elm/Entities/Document.elm
@@ -1,16 +1,18 @@
 module Entities.Document exposing
-    ( Document, Attribute, SearchMatching
-    , init, attributeValue
-    , File, Files
+    ( Document, Attribute, SearchMatching, Files, File
+    , init
+    , attributeValue, hasPresentation
     )
 
 {-| The metadata of a document and its attributes.
 
-@docs Document, Attribute, SearchMatching
-@docs init, attributeValue
+@docs Document, Attribute, SearchMatching, Files, File
+@docs init
+@docs attributeValue, hasPresentation
 
 -}
 
+import Constants
 import Entities.Markup exposing (Markup)
 import List.Extra
 import Types.Id exposing (DocumentId)
@@ -98,3 +100,17 @@ attributeValue key document =
         (\attribute -> attribute.field == key)
         document.attributes
         |> Maybe.map (.value >> Maybe.withDefault Entities.Markup.empty)
+
+
+hasPresentation : Document -> Bool
+hasPresentation document =
+    case document.files of
+        Nothing ->
+            False
+
+        Just files ->
+            List.any
+                (\file ->
+                    file.filetype == Constants.filetypes.presentation
+                )
+                files

--- a/frontend/src/elm/Entities/Document.elm
+++ b/frontend/src/elm/Entities/Document.elm
@@ -1,14 +1,14 @@
 module Entities.Document exposing
     ( Document, Attribute, SearchMatching, Files, File
     , init
-    , attributeValue, hasPresentation
+    , attributeValue, hasPresentation, hasDocumentPdf
     )
 
 {-| The metadata of a document and its attributes.
 
 @docs Document, Attribute, SearchMatching, Files, File
 @docs init
-@docs attributeValue, hasPresentation
+@docs attributeValue, hasPresentation, hasDocumentPdf
 
 -}
 
@@ -112,5 +112,20 @@ hasPresentation document =
             List.any
                 (\file ->
                     file.filetype == Constants.filetypes.presentation
+                )
+                files
+
+
+hasDocumentPdf : Document -> Bool
+hasDocumentPdf document =
+    case document.files of
+        Nothing ->
+            False
+
+        Just files ->
+            List.any
+                (\file ->
+                    (file.filetype == Constants.filetypes.document)
+                        && (file.mimetype == "application/pdf")
                 )
                 files

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -129,12 +129,42 @@ viewDocument context model document residence =
           else
             Html.div
                 [ Html.Attributes.class "thumbnail" ]
-                [ Html.img
-                    [ Html.Attributes.src
-                        (Constants.externalServerUrls.presentation document.id)
-                    ]
-                    []
+                [ (if Document.hasDocumentPdf document then
+                    \html ->
+                        Html.a
+                            [ Html.Attributes.href (Constants.externalServerUrls.showDocumentPdf document.id)
+                            , Html.Attributes.target "_blank"
+                            , Html.Attributes.title <|
+                                Localization.string context.config
+                                    { en = "Open fulltext in new window"
+                                    , de = "Volltext in neuem Fenster öffnen"
+                                    }
+                            ]
+                            [ html ]
+
+                   else
+                    identity
+                  )
+                    (Html.img
+                        [ Html.Attributes.src
+                            (Constants.externalServerUrls.presentation document.id)
+                        ]
+                        []
+                    )
                 ]
+        , if Document.hasDocumentPdf document then
+            Html.div [ Html.Attributes.class "download-link" ]
+                [ Html.a
+                    [ Html.Attributes.href (Constants.externalServerUrls.downloadDocumentPdf document.id) ]
+                    [ Localization.text context.config
+                        { en = "Download PDF"
+                        , de = "PDF herunterladen"
+                        }
+                    ]
+                ]
+
+          else
+            Html.text ""
         , Html.div [ Html.Attributes.class "header" ]
             [ Html.div [ Html.Attributes.class "metadatatype" ]
                 [ Html.text document.metadatatypeName ]

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -123,7 +123,7 @@ viewDocument context model document residence =
                     }
                 ]
             ]
-        , if context.config.hideThumbnails then
+        , if context.config.hideThumbnails || not (Document.hasPresentation document) then
             Html.text ""
 
           else


### PR DESCRIPTION
- Add API function to query the files of a document
    - For each file the API returns the fields `filetype` and `mimetype`
    - The file types "thumb" and "presentation" are listed regardless of the "data" access right
    - The other file types are listed only if the "data" access right is given
- Details view shows presentation image only if available
- Details view shows link to download or open the PDF document if available