### PR TITLE
Amend upper navigation

### DIFF
--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -191,6 +191,13 @@ article {
 .fixed-facet-filter .aspect-name {
   font-weight: bold;
 }
+.fixed-facet-filter .visual-button {
+  padding: 0rem 0.35rem;
+  line-height: 100%;
+}
+.fixed-facet-filter .visual-button svg {
+  height: 1.2ex;
+}
 .fixed-facet-filter .separator {
   margin: 0 0.4em;
 }

--- a/frontend/src/elm/Types/Localization.elm
+++ b/frontend/src/elm/Types/Localization.elm
@@ -2,7 +2,7 @@ module Types.Localization exposing
     ( Language(..)
     , languageFromLanguageTag, languageToLanguageTag
     , Translations
-    , text, string
+    , string, text, title
     )
 
 {-| Types used for localization of the app.
@@ -12,11 +12,12 @@ Currently we offer English and German as UI languages.
 @docs Language
 @docs languageFromLanguageTag, languageToLanguageTag
 @docs Translations
-@docs text, string
+@docs string, text, title
 
 -}
 
-import Html exposing (Html)
+import Html exposing (Attribute, Html)
+import Html.Attributes
 
 
 {-| A text with translations into the supported languages
@@ -52,6 +53,12 @@ string config translations =
 text : Config c -> Translations -> Html msg
 text config translations =
     Html.text (string config translations)
+
+
+{-| -}
+title : Config c -> Translations -> Attribute msg
+title config translations =
+    Html.Attributes.title (string config translations)
 
 
 {-| -}

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -111,11 +111,10 @@ viewDocument context model document residence =
             [ Html.a
                 [ Html.Attributes.href
                     (Constants.externalServerUrls.documentPermanent document.id)
-                , Html.Attributes.title <|
-                    Localization.string context.config
-                        { en = "Persistent link to the document in mediaTUM"
-                        , de = "Dauerhafter Verweis auf das Dokument in mediaTUM"
-                        }
+                , Localization.title context.config
+                    { en = "Persistent link to the document in mediaTUM"
+                    , de = "Dauerhafter Verweis auf das Dokument in mediaTUM"
+                    }
                 ]
                 [ Localization.text context.config
                     { en = "Show this document in mediaTUM"
@@ -134,11 +133,10 @@ viewDocument context model document residence =
                         Html.a
                             [ Html.Attributes.href (Constants.externalServerUrls.showDocumentPdf document.id)
                             , Html.Attributes.target "_blank"
-                            , Html.Attributes.title <|
-                                Localization.string context.config
-                                    { en = "Open fulltext in new window"
-                                    , de = "Volltext in neuem Fenster öffnen"
-                                    }
+                            , Localization.title context.config
+                                { en = "Open fulltext in new window"
+                                , de = "Volltext in neuem Fenster öffnen"
+                                }
                             ]
                             [ html ]
 

--- a/frontend/src/elm/UI/Controls.elm
+++ b/frontend/src/elm/UI/Controls.elm
@@ -45,6 +45,7 @@ import Types.Route exposing (Route)
 import Types.SearchTerm as SearchTerm
 import Types.Selection as Selection exposing (Sorting(..))
 import UI.Icons
+import Utils
 import Utils.List
 
 
@@ -434,8 +435,6 @@ viewFtsFilter config aspect searchText =
             , Html.button
                 [ Html.Attributes.type_ "button"
                 , Html.Attributes.class "visual-button"
-
-                -- , Html.Attributes.disabled beingEdited
                 , Html.Events.onClick (RemoveFtsFilter aspect)
                 , Html.Attributes.class "filter-button"
                 ]
@@ -509,8 +508,8 @@ viewFacetFilterButtons : Context -> List Selection.FacetFilter -> Html Msg
 viewFacetFilterButtons context listOfFacetFilters =
     Html.div []
         [ Localization.text context.config
-            { en = "Select: "
-            , de = "Auswählen: "
+            { en = "Filter by: "
+            , de = "Filtern nach: "
             }
         , Html.span
             [ Html.Attributes.class "facet-aspect-buttons" ]
@@ -546,16 +545,19 @@ viewSelectedFacetFilters context listOfFacetFilters =
         listOfHtml =
             listOfFacetFilters
                 |> Utils.List.mapAndMarkLast (viewFacetFilter context.config)
+
+        numberOfFilters =
+            List.length listOfFacetFilters
     in
-    if List.isEmpty listOfHtml then
+    if numberOfFilters == 0 then
         Html.text ""
 
     else
         Html.div []
             (Html.span []
                 [ Localization.text context.config
-                    { en = "Selected: "
-                    , de = "Ausgewählt: "
+                    { en = (numberOfFilters > 1) |> Utils.ifElse "Active filters: " "Active filter: "
+                    , de = "Aktive Filter: "
                     }
                 ]
                 :: listOfHtml
@@ -579,14 +581,15 @@ viewFacetFilter config isLastElement ( aspect, value ) =
         , Html.text " "
         , Html.button
             [ Html.Attributes.type_ "button"
-            , Html.Attributes.class "text-button"
-            , Html.Events.onClick (RemoveFacetFilter aspect)
-            ]
-            [ Localization.text config
-                { en = "(unselect)"
-                , de = "(abwählen)"
+            , Html.Attributes.class "visual-button"
+            , Localization.title config
+                { en = "(remove filter)"
+                , de = "(Filter entfernen)"
                 }
+            , Html.Events.onClick (RemoveFacetFilter aspect)
+            , Html.Attributes.class "filter-button"
             ]
+            [ UI.Icons.clear ]
         , if isLastElement then
             Html.text ""
 


### PR DESCRIPTION
- Wording (en): "Filter by", "Active filters"
- Buttons to remove the filter are now small visual buttons instead of text buttons
