### PR TITLE
Extend document details view

### DIFF
--- a/backend/src/sql/config/config.sql
+++ b/backend/src/sql/config/config.sql
@@ -24,7 +24,7 @@ insert into config.masks_by_purpose
     (purpose, mask_names)
 values
     ('listing', '{"en": "nodesmall_en", "de": "nodesmall"}'::jsonb),
-    ('details', '{"en": "nodebig_en", "de": "nodebig"}'::jsonb)
+    ('details', '{"en": "node-hsb_en", "de": "node-hsb"}'::jsonb)
 ;
 
 insert into config.aspect_def

--- a/backend/src/sql/config/create-tables.sql
+++ b/backend/src/sql/config/create-tables.sql
@@ -25,7 +25,7 @@ create table if not exists config.aspect_facet (
 );
 
 create table if not exists config.masks_by_purpose (
-    purpose text not null,
+    purpose text primary key not null,
     mask_names jsonb not null
 );
 

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -407,6 +407,9 @@ ul.folder-list ul.folder-list {
   vertical-align: middle;
   margin-right: 0.4em;
 }
+.details .license img {
+  height: 2.3ex;
+}
 
 .folder-head {
   display: flex;

--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -400,6 +400,13 @@ ul.folder-list ul.folder-list {
 {
   color: var(--color-primary);
 }
+.details .bibtex {
+  margin: 1ex 0;
+}
+.details .bibtex img {
+  vertical-align: middle;
+  margin-right: 0.4em;
+}
 
 .folder-head {
   display: flex;

--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -70,6 +70,7 @@ externalServerUrls :
     , documentPermanent : Id.DocumentId -> String
     , showDocumentPdf : Id.DocumentId -> String
     , downloadDocumentPdf : Id.DocumentId -> String
+    , urn : String -> String
     }
 externalServerUrls =
     let
@@ -86,6 +87,7 @@ externalServerUrls =
     , downloadDocumentPdf =
         \id ->
             "https://mediatum.ub.tum.de/download/" ++ Id.toString id ++ "/" ++ Id.toString id ++ ".pdf"
+    , urn = \urnSpec -> "http://nbn-resolving.de/urn/resolver.pl?" ++ urnSpec
     }
 
 

--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -70,6 +70,7 @@ externalServerUrls :
     , documentPermanent : Id.DocumentId -> String
     , bibtex : Id.DocumentId -> String
     , bibtexLogo : String
+    , licenseLogo : String -> String
     , showDocumentPdf : Id.DocumentId -> String
     , downloadDocumentPdf : Id.DocumentId -> String
     , urn : String -> String
@@ -86,6 +87,7 @@ externalServerUrls =
     , documentPermanent = "https://mediatum.ub.tum.de/" |> appendId
     , bibtex = \id -> "https://mediatum.ub.tum.de/export/" ++ Id.toString id ++ "/bibtex"
     , bibtexLogo = "https://mediatum.ub.tum.de/img/bibtex.gif"
+    , licenseLogo = \abbreviation -> "https://mediatum.ub.tum.de/img/" ++ abbreviation ++ ".png"
     , showDocumentPdf =
         \id ->
             "https://mediatum.ub.tum.de/doc/" ++ Id.toString id ++ "/" ++ Id.toString id ++ ".pdf"

--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -68,6 +68,8 @@ externalServerUrls :
     , presentation : Id.DocumentId -> String
     , item : String -> String
     , documentPermanent : Id.DocumentId -> String
+    , bibtex : Id.DocumentId -> String
+    , bibtexLogo : String
     , showDocumentPdf : Id.DocumentId -> String
     , downloadDocumentPdf : Id.DocumentId -> String
     , urn : String -> String
@@ -82,6 +84,8 @@ externalServerUrls =
     , presentation = "https://mediatum.ub.tum.de/thumb2/" |> appendId
     , item = \itemSpec -> "https://mediatum.ub.tum.de/?item=" ++ itemSpec ++ ".html"
     , documentPermanent = "https://mediatum.ub.tum.de/" |> appendId
+    , bibtex = \id -> "https://mediatum.ub.tum.de/export/" ++ Id.toString id ++ "/bibtex"
+    , bibtexLogo = "https://mediatum.ub.tum.de/img/bibtex.gif"
     , showDocumentPdf =
         \id ->
             "https://mediatum.ub.tum.de/doc/" ++ Id.toString id ++ "/" ++ Id.toString id ++ ".pdf"

--- a/frontend/src/elm/Constants.elm
+++ b/frontend/src/elm/Constants.elm
@@ -71,6 +71,7 @@ externalServerUrls :
     , showDocumentPdf : Id.DocumentId -> String
     , downloadDocumentPdf : Id.DocumentId -> String
     , urn : String -> String
+    , doi : String -> String
     }
 externalServerUrls =
     let
@@ -87,7 +88,8 @@ externalServerUrls =
     , downloadDocumentPdf =
         \id ->
             "https://mediatum.ub.tum.de/download/" ++ Id.toString id ++ "/" ++ Id.toString id ++ ".pdf"
-    , urn = \urnSpec -> "http://nbn-resolving.de/urn/resolver.pl?" ++ urnSpec
+    , urn = \urnSpec -> "https://nbn-resolving.de/urn/resolver.pl?" ++ urnSpec
+    , doi = \doiSpec -> "https://doi.org/" ++ doiSpec
     }
 
 

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -22,7 +22,7 @@ module UI.Article.Details exposing
 
 import Cache exposing (Cache)
 import Constants
-import Entities.Document as Document exposing (Document)
+import Entities.Document as Document exposing (Attribute, Document)
 import Entities.Markup as Markup exposing (Markup)
 import Entities.Residence as Residence exposing (Residence)
 import Html exposing (Html)
@@ -169,44 +169,15 @@ viewDocument context model document residence =
             ]
         , Html.table []
             [ Html.tbody []
-                (viewPotentialDissertationAuthor context.config document
-                    :: List.map
-                        viewAttribute
-                        document.attributes
+                (List.map
+                    viewAttribute
+                    document.attributes
                 )
             ]
         , viewBibtex context.config document
         , viewSearchMatching context.config document.searchMatching
         , viewResidence context residence
         ]
-
-
-{-| Work around a peculiarity of the current TUM database, regarding documents with schema `diss`.
-
-When queried by mask `nodebig` or `nodebig_en`, there is no maskitem which contains the author's name.
-But for most documents with schema `diss` the author's name is given by the document's name,
-which is a separate column in table `mediatum.node`.
-
-So, in these cases we add a synthetical attribute to display the author's name.
-
--}
-viewPotentialDissertationAuthor : Config -> Document -> Html Msg
-viewPotentialDissertationAuthor config document =
-    if document.metadatatypeName == "Dissertation" then
-        viewAttribute
-            { field = "author-from-document-name"
-            , name =
-                Localization.string config { en = "Author", de = "Autor" }
-            , value =
-                Just
-                    (Markup.parse
-                        (Markup.SpanClass "unparsable")
-                        document.name
-                    )
-            }
-
-    else
-        Html.text ""
 
 
 viewBibtex : Config -> Document -> Html msg
@@ -290,7 +261,7 @@ keys =
     }
 
 
-viewAttribute : { a | name : String, value : Maybe Markup, field : String } -> Html msg
+viewAttribute : Attribute -> Html msg
 viewAttribute attribute =
     case attribute.value of
         Just value ->

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -249,6 +249,7 @@ keys :
     , yearmonth : Regex.Regex
     , date : Regex.Regex
     , wwwAddress : Regex.Regex
+    , urn : Regex.Regex
     }
 keys =
     let
@@ -259,6 +260,7 @@ keys =
     , yearmonth = regex "yearmonth"
     , date = regex "date"
     , wwwAddress = regex "www-address"
+    , urn = regex "^urn$"
     }
 
 
@@ -287,6 +289,9 @@ viewAttribute attribute =
 
                                 else if isField keys.wwwAddress then
                                     Markup.renderWwwAddress
+
+                                else if isField keys.urn then
+                                    Markup.renderUrn
 
                                 else
                                     identity

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -175,6 +175,7 @@ viewDocument context model document residence =
                         document.attributes
                 )
             ]
+        , viewBibtex context.config document
         , viewSearchMatching context.config document.searchMatching
         , viewResidence context residence
         ]
@@ -206,6 +207,29 @@ viewPotentialDissertationAuthor config document =
 
     else
         Html.text ""
+
+
+viewBibtex : Config -> Document -> Html msg
+viewBibtex config document =
+    Html.div
+        [ Html.Attributes.class "bibtex" ]
+        [ Html.a
+            [ Html.Attributes.href (Constants.externalServerUrls.bibtex document.id)
+            , Html.Attributes.target "_blank"
+            , Localization.title config
+                { en = "Open BibTeX information in new window"
+                , de = "BibTeX Informationen in neuem Fenster öffnen"
+                }
+            ]
+            [ Html.img [ Html.Attributes.src Constants.externalServerUrls.bibtexLogo ] []
+            , Html.text "BibTex"
+            ]
+        ]
+
+
+
+-- <a href="/export/1591291/bibtex" target="bibtexdocument" title="BibTeX Informationen in neuem Fenster öffnen">
+-- <img src="/img/bibtex.gif">&nbsp;BibTeX</a>
 
 
 viewSearchMatching : Config -> Maybe Document.SearchMatching -> Html msg

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -246,6 +246,7 @@ keys :
     , wwwAddress : Regex.Regex
     , urn : Regex.Regex
     , doi : Regex.Regex
+    , license : Regex.Regex
     }
 keys =
     let
@@ -258,6 +259,7 @@ keys =
     , wwwAddress = regex "www-address"
     , urn = regex "^urn$"
     , doi = regex "^doi$"
+    , license = regex "^license$"
     }
 
 
@@ -292,6 +294,9 @@ viewAttribute attribute =
 
                                 else if isField keys.doi then
                                     Markup.renderDoi
+
+                                else if isField keys.license then
+                                    Markup.renderLicense
 
                                 else
                                     identity

--- a/frontend/src/elm/UI/Article/Details.elm
+++ b/frontend/src/elm/UI/Article/Details.elm
@@ -250,6 +250,7 @@ keys :
     , date : Regex.Regex
     , wwwAddress : Regex.Regex
     , urn : Regex.Regex
+    , doi : Regex.Regex
     }
 keys =
     let
@@ -261,6 +262,7 @@ keys =
     , date = regex "date"
     , wwwAddress = regex "www-address"
     , urn = regex "^urn$"
+    , doi = regex "^doi$"
     }
 
 
@@ -292,6 +294,9 @@ viewAttribute attribute =
 
                                 else if isField keys.urn then
                                     Markup.renderUrn
+
+                                else if isField keys.doi then
+                                    Markup.renderDoi
 
                                 else
                                     identity


### PR DESCRIPTION
- Fix primary key in table config.masks_by_purpose.
- Use new custom masks `node-hsb` / `node-hsb_en` for details view.
    - These masks don't include fields that are computed from other fields, which is not yes implemented by our backend.
    - This applies in particular to the fields representing DOI and URN.
- Render URN links in details view.
- Render DOI links in details view.
- Render BibTex link in details view.
- Remove work-around about author names of dissertations.
    - The new masks used for the details view now include an appropriate author field.
- Render license image and link in details view.